### PR TITLE
Suport asset delete/update

### DIFF
--- a/examples/morphology.ipynb
+++ b/examples/morphology.ipynb
@@ -162,8 +162,7 @@
     "        file_content_type=\"application/swc\",\n",
     "        token=token,\n",
     "    )\n",
-    "    rprint(asset2)\n",
-    "    morphology = morphology.evolve(assets=[asset1, asset2])"
+    "    rprint(asset2)"
    ]
   },
   {
@@ -181,8 +180,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "\n",
+    "# with assets included (default)\n",
     "fetched = client.get(entity_id=registered.id, entity_type=ReconstructionMorphology, token=token)\n",
     "rprint(fetched)\n",
+    "\n",
+    "# without assets\n",
     "fetched_wout_assets = client.get(\n",
     "    entity_id=registered.id, entity_type=ReconstructionMorphology, token=token, with_assets=False\n",
     ")\n",
@@ -204,6 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "\n",
     "for asset in fetched.assets:\n",
     "    if asset.content_type == \"application/swc\":\n",
     "        client.download_file(\n",
@@ -224,6 +228,95 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6879c149-3f59-4ee6-b878-92bdc6038de9",
+   "metadata": {},
+   "source": [
+    "## Delete asset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a211674-54d2-498f-983a-ab3f3675087d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for asset in fetched.assets:\n",
+    "    if asset.content_type == \"application/swc\":\n",
+    "        print(\"Deleting asset \", asset.id)\n",
+    "        deleted_asset = client.delete_asset(\n",
+    "            entity_id=fetched.id,\n",
+    "            entity_type=type(registered),\n",
+    "            asset_id=asset.id,\n",
+    "            token=token,\n",
+    "        )\n",
+    "        break\n",
+    "\n",
+    "rprint(deleted_asset)\n",
+    "\n",
+    "fetched = client.get(entity_id=registered.id, entity_type=ReconstructionMorphology, token=token)\n",
+    "rprint(fetched.assets)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34b39d9d-2b08-4933-b3cb-3f9a9c08004b",
+   "metadata": {},
+   "source": [
+    "## Update asset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69d44c3c-b07c-46d2-978f-98b1b80b5212",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# update h5 asset with another file\n",
+    "with tempfile.TemporaryDirectory() as tdir:\n",
+    "    file1 = Path(tdir, \"updated.h5\")\n",
+    "    file1.write_text(\"updated h5\")\n",
+    "    file1.touch()\n",
+    "\n",
+    "    for asset in fetched.assets:\n",
+    "        if asset.content_type == \"application/h5\":\n",
+    "            updated_asset = client.update_asset_file(\n",
+    "                entity_id=fetched.id,\n",
+    "                entity_type=type(registered),\n",
+    "                asset_id=asset.id,\n",
+    "                file_name=asset1.path,\n",
+    "                file_path=file1,\n",
+    "                file_content_type=asset.content_type,\n",
+    "                token=token,\n",
+    "            )\n",
+    "            break\n",
+    "\n",
+    "\n",
+    "# synchronize morphology with new server data\n",
+    "fetched = client.get(entity_id=registered.id, entity_type=ReconstructionMorphology, token=token)\n",
+    "rprint(fetched.assets)\n",
+    "\n",
+    "\n",
+    "# download updated file and check it was successfully updated\n",
+    "for asset in fetched.assets:\n",
+    "    if asset.content_type == \"application/h5\":\n",
+    "        client.download_file(\n",
+    "            entity_id=fetched.id,\n",
+    "            entity_type=type(fetched),\n",
+    "            asset_id=updated_asset.id,\n",
+    "            output_path=\"./my-file.h5\",\n",
+    "            token=token,\n",
+    "        )\n",
+    "        content = client.download_content(\n",
+    "            entity_id=fetched.id, entity_type=type(fetched), asset_id=asset.id, token=token\n",
+    "        )\n",
+    "        break\n",
+    "print(content)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f15c808c-c454-4277-9ec4-587922ac74f3",
    "metadata": {},
    "source": [
@@ -239,7 +332,7 @@
    "source": [
     "it = client.search(\n",
     "    entity_type=ReconstructionMorphology,\n",
-    "    query={\"name\": \"my-morph\", \"page\": 1, \"page_size\": 2},\n",
+    "    query={\"name__ilike\": \"my-morph\", \"page\": 1, \"page_size\": 2},\n",
     "    token=token,\n",
     "    limit=0,\n",
     ")\n",

--- a/examples/morphology.ipynb
+++ b/examples/morphology.ipynb
@@ -180,7 +180,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "# with assets included (default)\n",
     "fetched = client.get(entity_id=registered.id, entity_type=ReconstructionMorphology, token=token)\n",
     "rprint(fetched)\n",
@@ -207,7 +206,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "for asset in fetched.assets:\n",
     "    if asset.content_type == \"application/swc\":\n",
     "        client.download_file(\n",
@@ -312,7 +310,7 @@
     "            entity_id=fetched.id, entity_type=type(fetched), asset_id=asset.id, token=token\n",
     "        )\n",
     "        break\n",
-    "print(content)\n"
+    "print(content)"
    ]
   },
   {

--- a/src/entitysdk/client.py
+++ b/src/entitysdk/client.py
@@ -610,5 +610,4 @@ def delete_asset(
         token=token,
         http_client=http_client,
     )
-    print(response.json())
     return serdes.deserialize_entity(response.json(), Asset)

--- a/src/entitysdk/client.py
+++ b/src/entitysdk/client.py
@@ -333,7 +333,10 @@ class Client:
         project_context: ProjectContext | None = None,
         token: str,
     ) -> Asset:
-        """Update an entity's asset file."""
+        """Update an entity's asset file.
+
+        Note: This operation is not atomic. Deletion can succeed and upload can fail.
+        """
         self.delete_asset(
             entity_id=entity_id,
             entity_type=entity_type,

--- a/src/entitysdk/client.py
+++ b/src/entitysdk/client.py
@@ -437,11 +437,7 @@ def get_entity_assets(
         token=token,
         http_client=http_client,
     )
-    return [
-        serdes.deserialize_entity(asset, Asset)
-        for asset in response.json()["data"]
-        if asset["status"] != "deleted"
-    ]
+    return [serdes.deserialize_entity(asset, Asset) for asset in response.json()["data"]]
 
 
 def register_entity(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -191,3 +191,55 @@ def test_client_get(mock_route, client, mock_asset_response, api_url, project_co
     )
     assert res.id == 1
     assert len(res.assets) == 2
+
+
+@pytest.fixture
+def mock_asset_delete_response():
+    return {
+        "path": "buffer.h5",
+        "full_path": "private/103d7868/103d7868/assets/reconstruction_morphology/8703/buffer.h5",
+        "bucket_name": "obi-private",
+        "is_directory": False,
+        "content_type": "application/swc",
+        "size": 18,
+        "sha256_digest": "47ddc1b6e05dcbfbd2db9dcec4a49d83c6f9f10ad595649bacdcb629671fd954",
+        "meta": {},
+        "id": 16393,
+        "status": "deleted",
+    }
+
+
+@patch("entitysdk.route.get_route_name")
+def test_client_delete_asset(mock_route, client, mock_asset_delete_response, project_context):
+    mock_route.return_value = "reconstruction_morphology"
+    client._http_client.request.return_value = Mock(json=lambda: mock_asset_delete_response)
+
+    res = client.delete_asset(
+        entity_id=1,
+        entity_type=None,
+        asset_id=2,
+        token="foo",
+    )
+
+    assert res.status == "deleted"
+
+
+@patch("entitysdk.route.get_route_name")
+def test_client_update_asset(mock_route, tmp_path, client, mock_asset_response):
+    mock_route.return_value = "reconstruction_morphology"
+    client._http_client.request.return_value = Mock(json=lambda: mock_asset_response)
+
+    path = tmp_path / "file.txt"
+    path.touch()
+
+    res = client.update_asset_file(
+        entity_id=1,
+        entity_type=None,
+        file_path=path,
+        file_name="foo.txt",
+        file_content_type="application/swc",
+        asset_id=2,
+        token="foo",
+    )
+
+    assert res.status == "completed"


### PR DESCRIPTION
* Add delete_asset_file client method
* Add update_asset_file client method
* Filter out assets with status "deleted" when fetching for a morphology

Note that updating is taking place by deleting the existing entity's asset and creating a new one with different id.