### PR TITLE
Improve stream_paginated_request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,7 +165,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # PyPI configuration file
 .pypirc

--- a/src/entitysdk/config.py
+++ b/src/entitysdk/config.py
@@ -10,12 +10,12 @@ class Settings(BaseSettings):
     """Constants for this library."""
 
     page_size: Annotated[
-        int,
+        int | None,
         Field(
             env="ENTITYSDK_PAGE_SIZE",
-            description="Default pagination page size.",
+            description="Default pagination page size, or None to use server default.",
         ),
-    ] = 20
+    ] = None
 
 
 settings = Settings()

--- a/src/entitysdk/config.py
+++ b/src/entitysdk/config.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
     page_size: Annotated[
         int | None,
         Field(
-            env="ENTITYSDK_PAGE_SIZE",
+            alias="ENTITYSDK_PAGE_SIZE",
             description="Default pagination page size, or None to use server default.",
         ),
     ] = None

--- a/src/entitysdk/models/response.py
+++ b/src/entitysdk/models/response.py
@@ -1,0 +1,20 @@
+"""Response models."""
+
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+
+class PaginationResponse(BaseModel):
+    """Pagination details returned by the entitycore service."""
+
+    page: Annotated[int, Field(ge=1)]
+    page_size: Annotated[int, Field(ge=1)]
+    total_items: Annotated[int, Field(ge=0)]
+
+
+class ListResponse(BaseModel):
+    """Response returned by the entitycore service."""
+
+    data: list
+    pagination: PaginationResponse

--- a/src/entitysdk/util.py
+++ b/src/entitysdk/util.py
@@ -101,14 +101,14 @@ def stream_paginated_request(
         )
         json_data = response.json()["data"]
 
-        if not json_data:
-            return
-
         for data in json_data:
             yield data
             number_of_items += 1
 
             if limit and number_of_items == limit:
                 return
+
+        if len(json_data) < page_size:
+            return
 
         page += 1

--- a/src/entitysdk/util.py
+++ b/src/entitysdk/util.py
@@ -99,7 +99,9 @@ def stream_paginated_request(
             token=token,
             http_client=http_client,
         )
-        json_data = response.json()["data"]
+        json_response = response.json()
+        json_data = json_response["data"]
+        total_items = json_response["total_items"]
 
         for data in json_data:
             yield data
@@ -108,7 +110,7 @@ def stream_paginated_request(
             if limit and number_of_items == limit:
                 return
 
-        if len(json_data) < page_size:
+        if len(json_data) < page_size or number_of_items >= total_items:
             return
 
         page += 1

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from uuid import UUID
 
 import pytest
 
@@ -14,11 +14,25 @@ def api_url():
 @pytest.fixture(scope="session")
 def project_context():
     return ProjectContext(
-        project_id="103d7868-147e-4f07-af0d-71d8568f575c",
-        virtual_lab_id="103d7868-147e-4f07-af0d-71d8568f575c",
+        project_id=UUID("103d7868-147e-4f07-af0d-71d8568f575c"),
+        virtual_lab_id=UUID("103d7868-147e-4f07-af0d-71d8568f575c"),
     )
+
+
+@pytest.fixture(scope="session")
+def auth_token():
+    return "mock-token"
+
+
+@pytest.fixture(scope="session")
+def request_headers(project_context, auth_token):
+    return {
+        "project-id": str(project_context.project_id),
+        "virtual-lab-id": str(project_context.virtual_lab_id),
+        "Authorization": f"Bearer {auth_token}",
+    }
 
 
 @pytest.fixture
 def client(project_context, api_url):
-    return Client(api_url=api_url, project_context=project_context, http_client=Mock())
+    return Client(api_url=api_url, project_context=project_context)

--- a/tests/unit/models/test_morphology.py
+++ b/tests/unit/models/test_morphology.py
@@ -1,5 +1,3 @@
-from unittest.mock import Mock
-
 import pytest
 
 from entitysdk.models.morphology import (
@@ -95,36 +93,31 @@ def json_morphology_expanded():
     }
 
 
-def test_read_reconstruction_morphology(client, json_morphology_expanded):
-    client._http_client.request.return_value = Mock(json=lambda: json_morphology_expanded)
+def test_read_reconstruction_morphology(client, httpx_mock, auth_token, json_morphology_expanded):
+    httpx_mock.add_response(method="GET", json=json_morphology_expanded)
 
     entity = client.get(
         entity_id=1,
         entity_type=ReconstructionMorphology,
-        token="mock-token",
+        token=auth_token,
         with_assets=False,
     )
 
     assert entity.id == 6466
 
 
-def test_register_reconstruction_morphology(client, morphology):
-    client._http_client.request.return_value = Mock(
-        json=lambda: morphology.model_dump() | {"id": 1}
-    )
+def test_register_reconstruction_morphology(client, httpx_mock, auth_token, morphology):
+    httpx_mock.add_response(method="POST", json=morphology.model_dump() | {"id": 1})
 
-    registered = client.register(entity=morphology, token="mock-token")
+    registered = client.register(entity=morphology, token=auth_token)
 
     assert registered.id == 1
     assert registered.name == morphology.name
 
 
-def test_update_reconstruction_morphology(client, morphology):
+def test_update_reconstruction_morphology(client, httpx_mock, auth_token, morphology):
     morphology = morphology.evolve(id=1)
-
-    client._http_client.request.return_value = Mock(
-        json=lambda: morphology.model_dump() | {"id": 1, "name": "foo"}
-    )
+    httpx_mock.add_response(method="PATCH", json=morphology.model_dump() | {"id": 1, "name": "foo"})
 
     updated = client.update(
         entity_id=1,
@@ -132,7 +125,7 @@ def test_update_reconstruction_morphology(client, morphology):
         attrs_or_entity={
             "name": "foo",
         },
-        token="mock-token",
+        token=auth_token,
     )
 
     assert updated.id == 1

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,5 +1,5 @@
 import io
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -15,14 +15,19 @@ def test_client_project_context__raises():
         client._project_context(override_context=None)
 
 
-def test_client_search(client):
-    client._http_client.request.return_value = Mock(json=lambda: {"data": [{"id": 1}, {"id": 2}]})
-
+def test_client_search(client, httpx_mock, auth_token):
+    httpx_mock.add_response(
+        method="GET",
+        json={
+            "data": [{"id": 1}, {"id": 2}],
+            "pagination": {"page": 1, "page_size": 10, "total_items": 2},
+        },
+    )
     res = list(
         client.search(
             entity_type=Entity,
             query={"name": "foo"},
-            token="mock-token",
+            token=auth_token,
             limit=2,
         )
     )
@@ -31,14 +36,14 @@ def test_client_search(client):
     assert res[1].id == 2
 
 
-def test_client_update(client):
-    client._http_client.request.return_value = Mock(json=lambda: {"id": 1})
+def test_client_update(client, httpx_mock, auth_token):
+    httpx_mock.add_response(method="PATCH", json={"id": 1})
 
     res = client.update(
         entity_id=1,
         entity_type=Entity,
-        attrs_or_entity=Entity(id="1"),
-        token="mock-token",
+        attrs_or_entity=Entity(id=1),
+        token=auth_token,
     )
 
     assert res.id == 1
@@ -54,15 +59,28 @@ def mock_asset_response():
         "is_directory": False,
         "content_type": "text/plain",
         "size": 100,
-        "status": "completed",
+        "status": "created",
         "meta": {},
         "sha256_digest": "sha256_digest",
     }
 
 
-def test_client_upload_file(tmp_path, client, mock_asset_response, api_url, project_context):
-    client._http_client.request.return_value = Mock(json=lambda: mock_asset_response)
-    client._http_client.request.headers = {}
+def test_client_upload_file(
+    tmp_path,
+    client,
+    httpx_mock,
+    mock_asset_response,
+    api_url,
+    project_context,
+    auth_token,
+    request_headers,
+):
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{api_url}/entity/1/assets",
+        match_headers=request_headers,
+        json=mock_asset_response,
+    )
 
     path = tmp_path / "foo.h5"
     path.write_bytes(b"foo")
@@ -74,25 +92,29 @@ def test_client_upload_file(tmp_path, client, mock_asset_response, api_url, proj
         file_path=path,
         file_content_type="text/plain",
         file_metadata={"key": "value"},
-        token="mock-token",
+        token=auth_token,
     )
-
-    call_args = client._http_client.request.call_args
-
-    assert call_args.kwargs["method"] == "POST"
-    assert call_args.kwargs["url"] == f"{api_url}/entity/1/assets"
-    assert call_args.kwargs["headers"]["project-id"] == project_context.project_id
-    assert call_args.kwargs["headers"]["virtual-lab-id"] == project_context.virtual_lab_id
-    assert call_args.kwargs["headers"]["Authorization"] == "Bearer mock-token"
 
     assert res.id == 1
 
 
-def test_client_upload_content(client, mock_asset_response, api_url, project_context):
-    client._http_client.request.return_value = Mock(json=lambda: mock_asset_response)
-
+def test_client_upload_content(
+    client, httpx_mock, mock_asset_response, api_url, project_context, auth_token, request_headers
+):
     buffer = io.BytesIO(b"foo")
-
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{api_url}/entity/1/assets",
+        match_headers=request_headers,
+        match_files={
+            "file": (
+                "foo.txt",
+                buffer,
+                "text/plain",
+            )
+        },
+        json=mock_asset_response,
+    )
     res = client.upload_content(
         entity_id=1,
         entity_type=Entity,
@@ -100,60 +122,47 @@ def test_client_upload_content(client, mock_asset_response, api_url, project_con
         file_content=buffer,
         file_content_type="text/plain",
         file_metadata={"key": "value"},
-        token="mock-token",
-    )
-
-    client._http_client.request.assert_called_once_with(
-        method="POST",
-        url=f"{api_url}/entity/1/assets",
-        headers={
-            "project-id": project_context.project_id,
-            "virtual-lab-id": project_context.virtual_lab_id,
-            "Authorization": "Bearer mock-token",
-        },
-        json=None,
-        files={
-            "file": (
-                "foo.txt",
-                buffer,
-                "text/plain",
-            )
-        },
-        params=None,
-        follow_redirects=True,
+        token=auth_token,
     )
 
     assert res.id == 1
 
 
-def test_client_download_content(client, mock_asset_response, api_url, project_context):
-    client._http_client.request.return_value = Mock(content=b"foo")
+def test_client_download_content(
+    client, httpx_mock, mock_asset_response, api_url, project_context, auth_token, request_headers
+):
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/entity/1/assets/2/download",
+        match_headers=request_headers,
+        content=b"foo",
+    )
 
     res = client.download_content(
         entity_id=1,
         entity_type=Entity,
         asset_id=2,
-        token="mock-token",
+        token=auth_token,
     )
     assert res == b"foo"
 
-    client._http_client.request.assert_called_once_with(
+
+def test_client_download_file(
+    tmp_path,
+    client,
+    httpx_mock,
+    mock_asset_response,
+    api_url,
+    project_context,
+    auth_token,
+    request_headers,
+):
+    httpx_mock.add_response(
         method="GET",
         url=f"{api_url}/entity/1/assets/2/download",
-        headers={
-            "project-id": project_context.project_id,
-            "virtual-lab-id": project_context.virtual_lab_id,
-            "Authorization": "Bearer mock-token",
-        },
-        json=None,
-        params=None,
-        files=None,
-        follow_redirects=True,
+        match_headers=request_headers,
+        content=b"foo",
     )
-
-
-def test_client_download_file(tmp_path, client, mock_asset_response, api_url, project_context):
-    client._http_client.request.return_value = Mock(content=b"foo")
 
     output_path = tmp_path / "foo.h5"
 
@@ -162,31 +171,47 @@ def test_client_download_file(tmp_path, client, mock_asset_response, api_url, pr
         entity_type=Entity,
         asset_id=2,
         output_path=output_path,
-        token="mock-token",
+        token=auth_token,
     )
     assert output_path.read_bytes() == b"foo"
 
 
 @patch("entitysdk.route.get_route_name")
-def test_client_get(mock_route, client, mock_asset_response, api_url, project_context):
+def test_client_get(
+    mock_route,
+    client,
+    httpx_mock,
+    mock_asset_response,
+    api_url,
+    project_context,
+    auth_token,
+    request_headers,
+):
     class EntityWithAssets(HasAssets, Entity):
         """Entity plus assets."""
 
     mock_route.return_value = "entity"
 
-    def mock_request(*args, **kwargs):
-        if "assets" in kwargs["url"]:
-            return Mock(
-                json=lambda: {"data": [mock_asset_response, mock_asset_response]},
-            )
-        return Mock(json=lambda: {"id": 1})
-
-    client._http_client.request = mock_request
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/entity/1",
+        match_headers=request_headers,
+        json={"id": 1},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/entity/1/assets",
+        match_headers=request_headers,
+        json={
+            "data": [mock_asset_response, mock_asset_response],
+            "pagination": {"page": 1, "page_size": 10, "total_items": 2},
+        },
+    )
 
     res = client.get(
         entity_id=1,
         entity_type=EntityWithAssets,
-        token="mock-token",
+        token=auth_token,
         with_assets=True,
     )
     assert res.id == 1
@@ -210,24 +235,61 @@ def mock_asset_delete_response():
 
 
 @patch("entitysdk.route.get_route_name")
-def test_client_delete_asset(mock_route, client, mock_asset_delete_response, project_context):
-    mock_route.return_value = "reconstruction_morphology"
-    client._http_client.request.return_value = Mock(json=lambda: mock_asset_delete_response)
+def test_client_delete_asset(
+    mock_route,
+    client,
+    httpx_mock,
+    mock_asset_delete_response,
+    api_url,
+    project_context,
+    auth_token,
+    request_headers,
+):
+    mock_route.return_value = "reconstruction-morphology"
+
+    httpx_mock.add_response(
+        method="DELETE",
+        url=f"{api_url}/reconstruction-morphology/1/assets/2",
+        match_headers=request_headers,
+        json=mock_asset_delete_response,
+    )
 
     res = client.delete_asset(
         entity_id=1,
         entity_type=None,
         asset_id=2,
-        token="foo",
+        token=auth_token,
     )
 
     assert res.status == "deleted"
 
 
 @patch("entitysdk.route.get_route_name")
-def test_client_update_asset(mock_route, tmp_path, client, mock_asset_response):
-    mock_route.return_value = "reconstruction_morphology"
-    client._http_client.request.return_value = Mock(json=lambda: mock_asset_response)
+def test_client_update_asset(
+    mock_route,
+    tmp_path,
+    client,
+    httpx_mock,
+    mock_asset_response,
+    api_url,
+    project_context,
+    auth_token,
+    request_headers,
+):
+    mock_route.return_value = "reconstruction-morphology"
+
+    httpx_mock.add_response(
+        method="DELETE",
+        url=f"{api_url}/reconstruction-morphology/1/assets/2",
+        match_headers=request_headers,
+        json=mock_asset_response,
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{api_url}/reconstruction-morphology/1/assets",
+        match_headers=request_headers,
+        json=mock_asset_response,
+    )
 
     path = tmp_path / "file.txt"
     path.touch()
@@ -239,7 +301,7 @@ def test_client_update_asset(mock_route, tmp_path, client, mock_asset_response):
         file_name="foo.txt",
         file_content_type="application/swc",
         asset_id=2,
-        token="foo",
+        token=auth_token,
     )
 
-    assert res.status == "completed"
+    assert res.status == "created"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,13 @@
+from entitysdk import config as test_module
+
+
+def test_settings_without_env(monkeypatch):
+    monkeypatch.delenv("ENTITYSDK_PAGE_SIZE", raising=False)
+    settings = test_module.Settings()
+    assert settings.page_size is None
+
+
+def test_settings_with_env(monkeypatch):
+    monkeypatch.setenv("ENTITYSDK_PAGE_SIZE", "123")
+    settings = test_module.Settings()
+    assert settings.page_size == 123

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ path = src/{[base]name}
 testdeps =
     pytest
     pytest-cov
+    pytest-httpx
     coverage[toml]
 
 [tox]


### PR DESCRIPTION
Improve stream_paginated_request

- Avoid extra call to entitycore
- Set config.page_size to None and use server default unless it's specified
- Validate the list response from entitycore
- Use the pagination details returned by the service
- Use pytest-httpx in tests
- Fix ENTITYSDK_PAGE_SIZE env variable
