### PR TITLE
Setup integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,10 @@ addopts = [
     "-vv",
     "-ra",
     "--import-mode=importlib",
-    "--cov=entitysdk",
     "--durations=10",
     "--durations-min=1.0",
 ]
+testpaths = ["tests/unit"]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ addopts = [
     "--durations=10",
     "--durations-min=1.0",
 ]
-testpaths = ["tests/unit"]
 
 [tool.ruff]
 line-length = 100

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+
+from entitysdk.client import Client
+from entitysdk.common import ProjectContext
+
+
+@pytest.fixture(scope="session")
+def api_url():
+    return "http://localhost:8000"
+
+
+@pytest.fixture(scope="session")
+def project_context():
+    return ProjectContext(
+        virtual_lab_id="a98b7abc-fc46-4700-9e3d-37137812c730",
+        project_id="0dbced5f-cc3d-488a-8c7f-cfb8ea039dc6",
+    )
+
+
+@pytest.fixture(scope="session")
+def client(project_context, api_url):
+    class MockTokenManager:
+        def get_token(self):
+            return "mock-token"
+
+    return Client(
+        api_url=api_url, project_context=project_context, token_manager=MockTokenManager()
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from entitysdk.client import Client
@@ -6,7 +7,7 @@ from entitysdk.common import ProjectContext
 
 @pytest.fixture(scope="session")
 def api_url():
-    return "http://localhost:8000"
+    return os.environ["DB_API_URL"]
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from entitysdk.client import Client

--- a/tests/integration/test_searching.py
+++ b/tests/integration/test_searching.py
@@ -1,0 +1,29 @@
+import pytest
+
+from entitysdk.models.agent import Organization, Person
+from entitysdk.models.contribution import Role
+from entitysdk.models.morphology import (
+    License,
+    ReconstructionMorphology,
+    Species,
+    Strain,
+)
+from entitysdk.models.mtype import MTypeClass
+
+
+@pytest.mark.parametrize(
+    "entity_type",
+    [
+        License,
+        MTypeClass,
+        Person,
+        ReconstructionMorphology,
+        Role,
+        Species,
+        Strain,
+        Organization,
+    ],
+)
+def test_is_searchable(entity_type, client):
+    res = client.search_entity(entity_type=entity_type, limit=1).one()
+    assert res.id

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,7 +8,7 @@ from entitysdk.common import ProjectContext
 
 @pytest.fixture(scope="session")
 def api_url():
-    return "http://localhost:8000"
+    return "http://mock-host:8000"
 
 
 @pytest.fixture(scope="session")

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ minversion = 3.18
 deps =
     {[base]testdeps}
 commands =
-    python -m pytest --cov={[base]name} {posargs}
+    python -m pytest --cov={[base]name} tests/unit {posargs}
     python -m coverage xml
     python -m coverage html
 
@@ -66,4 +66,4 @@ commands =
 deps =
     {[base]testdeps}
 commands =
-    python -m pytest --cov={[base]name}.models tests/integration {posargs}
+    python -m pytest tests/integration {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -65,5 +65,7 @@ commands =
 [testenv:integration]
 deps =
     {[base]testdeps}
+setenv =
+    DB_API_URL = {env:DB_API_URL:http://localhost:8000}
 commands =
     python -m pytest tests/integration {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ minversion = 3.18
 deps =
     {[base]testdeps}
 commands =
-    python -m pytest {posargs}
+    python -m pytest --cov={[base]name} {posargs}
     python -m coverage xml
     python -m coverage html
 
@@ -61,3 +61,9 @@ commands =
         --ClearOutputPreprocessor.enabled=True \
         --ClearMetadataPreprocessor.enabled=True \
         --inplace {posargs:examples/*.ipynb}
+
+[testenv:integration]
+deps =
+    {[base]testdeps}
+commands =
+    python -m pytest --cov={[base]name}.models tests/integration {posargs}


### PR DESCRIPTION
Allow running integration tests using an entity core url.
```
tox -e integration
```
`DB_API_URL` is set in tox by default to `http://localhost:8000`