### PR TITLE
Allow constructing the ProjectContext from a vlab url

### DIFF
--- a/src/entitysdk/common.py
+++ b/src/entitysdk/common.py
@@ -1,12 +1,42 @@
 """Common stuff."""
 
-from dataclasses import dataclass
+import re
+from typing import Self
 from uuid import UUID
 
+from pydantic import BaseModel
 
-@dataclass
-class ProjectContext:
+from entitysdk.exception import EntitySDKError
+from entitysdk.typedef import DeploymentEnvironment
+
+VLAB_URL_PATTERN = re.compile(
+    r"^https:\/\/(?:(?P<staging>staging)\.)?openbraininstitute\.org"
+    r"\/app\/virtual-lab\/lab\/(?P<vlab>[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})"
+    r"\/project\/(?P<proj>[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})(?:\/.*)?$"
+)
+
+
+class ProjectContext(BaseModel):
     """Project context."""
 
     project_id: UUID
     virtual_lab_id: UUID
+    environment: DeploymentEnvironment | None = None
+
+    @classmethod
+    def from_vlab_url(cls, url: str) -> Self:
+        """Construct a ProjectContext from a virtual lab url."""
+        result = VLAB_URL_PATTERN.match(url)
+
+        if not result:
+            raise EntitySDKError(f"Badly formed vlab url: {url}")
+
+        env = (
+            DeploymentEnvironment.staging
+            if result.group("staging")
+            else DeploymentEnvironment.production
+        )
+        vlab_id = UUID(result.group("vlab"))
+        proj_id = UUID(result.group("proj"))
+
+        return cls(project_id=proj_id, virtual_lab_id=vlab_id, environment=env)

--- a/src/entitysdk/common.py
+++ b/src/entitysdk/common.py
@@ -13,7 +13,7 @@ UUID_RE = "[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}"
 
 
 VLAB_URL_PATTERN = re.compile(
-    r"^https:\/\/(?P<env>staging|www)?\.openbraininstitute\.org"
+    r"^https:\/\/(?P<env>staging|www)\.openbraininstitute\.org"
     rf"\/app\/virtual-lab\/lab\/(?P<vlab>{UUID_RE})"
     rf"\/project\/(?P<proj>{UUID_RE})(?:\/.*)?$"
 )

--- a/src/entitysdk/typedef.py
+++ b/src/entitysdk/typedef.py
@@ -1,5 +1,13 @@
 """Type definitions."""
 
 import uuid
+from enum import StrEnum
 
 ID = uuid.UUID
+
+
+class DeploymentEnvironment(StrEnum):
+    """Deployment environment."""
+
+    staging = "staging"
+    production = "production"

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -1,0 +1,89 @@
+import pytest
+
+from entitysdk import common as test_module
+from entitysdk.exception import EntitySDKError
+from entitysdk.typedef import DeploymentEnvironment
+
+VLAB_ID = "ff888f05-f314-4702-8a92-b86f754270bb"
+PROJ_ID = "f373e771-3a2f-4f45-ab59-0955efd7b1f4"
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (
+            f"https://staging.openbraininstitute.org/app/virtual-lab/lab/{VLAB_ID}/project/{PROJ_ID}/home",
+            test_module.ProjectContext(
+                virtual_lab_id=VLAB_ID,
+                project_id=PROJ_ID,
+                environment=DeploymentEnvironment.staging,
+            ),
+        ),
+        (
+            f"https://staging.openbraininstitute.org/app/virtual-lab/lab/{VLAB_ID}/project/{PROJ_ID}",
+            test_module.ProjectContext(
+                virtual_lab_id=VLAB_ID,
+                project_id=PROJ_ID,
+                environment=DeploymentEnvironment.staging,
+            ),
+        ),
+        (
+            f"https://openbraininstitute.org/app/virtual-lab/lab/{VLAB_ID}/project/{PROJ_ID}/home",
+            test_module.ProjectContext(
+                virtual_lab_id=VLAB_ID,
+                project_id=PROJ_ID,
+                environment=DeploymentEnvironment.production,
+            ),
+        ),
+        (
+            f"https://openbraininstitute.org/app/virtual-lab/lab/{VLAB_ID}/project/{PROJ_ID}",
+            test_module.ProjectContext(
+                virtual_lab_id=VLAB_ID,
+                project_id=PROJ_ID,
+                environment=DeploymentEnvironment.production,
+            ),
+        ),
+    ],
+)
+def test_project_context__from_vlab_url(url, expected):
+    res = test_module.ProjectContext.from_vlab_url(url)
+    assert res == expected
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_error", "expected_msg"),
+    [
+        ("asdf", EntitySDKError, "Badly formed vlab url"),
+        ("https://", EntitySDKError, "Badly formed vlab url"),
+        ("https://openbraininstitute.org", EntitySDKError, "Badly formed vlab url"),
+        ("https://staging.openbraininstitute.org", EntitySDKError, "Badly formed vlab url"),
+        (
+            "https://staging.openbraininstitute.org/app/virtual-lab/lab/foo",
+            EntitySDKError,
+            "Badly formed vlab url",
+        ),
+        (
+            "https://staging.openbraininstitute.org/app/virtual-lab/lab/foo/project/bar",
+            EntitySDKError,
+            "Badly formed vlab url",
+        ),
+        (
+            f"https://dev.openbraininstitute.org/app/virtual-lab/lab/{VLAB_ID}/project/{PROJ_ID}",
+            EntitySDKError,
+            "Badly formed vlab url",
+        ),
+        (
+            f"https://dev.openbraininstitute.org/app/virtual-lab/lab/foo/project/{PROJ_ID}",
+            EntitySDKError,
+            "Badly formed vlab url",
+        ),
+        (
+            f"https://dev.openbraininstitute.org/app/virtual-lab/lab/{VLAB_ID}/project/bar",
+            EntitySDKError,
+            "Badly formed vlab url",
+        ),
+    ],
+)
+def test_project_context__from_vlab_url__raises(url, expected_error, expected_msg):
+    with pytest.raises(expected_error, match=expected_msg):
+        test_module.ProjectContext.from_vlab_url(url)

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -28,7 +28,7 @@ PROJ_ID = "f373e771-3a2f-4f45-ab59-0955efd7b1f4"
             ),
         ),
         (
-            f"https://openbraininstitute.org/app/virtual-lab/lab/{VLAB_ID}/project/{PROJ_ID}/home",
+            f"https://www.openbraininstitute.org/app/virtual-lab/lab/{VLAB_ID}/project/{PROJ_ID}/home",
             test_module.ProjectContext(
                 virtual_lab_id=VLAB_ID,
                 project_id=PROJ_ID,
@@ -36,7 +36,7 @@ PROJ_ID = "f373e771-3a2f-4f45-ab59-0955efd7b1f4"
             ),
         ),
         (
-            f"https://openbraininstitute.org/app/virtual-lab/lab/{VLAB_ID}/project/{PROJ_ID}",
+            f"https://www.openbraininstitute.org/app/virtual-lab/lab/{VLAB_ID}/project/{PROJ_ID}",
             test_module.ProjectContext(
                 virtual_lab_id=VLAB_ID,
                 project_id=PROJ_ID,


### PR DESCRIPTION
The context will be built from a vlab url as follows:
```python
project_context = ProjectContext.from_vlab_url(url)
```
I also capture the deployment environment (staging/prod for now), which is stored in ProjectContext, for later constructing the api url.

Implements #32 