### PR TITLE
Do not remove Nones from payload to keep server happy

### DIFF
--- a/src/entitysdk/serdes.py
+++ b/src/entitysdk/serdes.py
@@ -22,7 +22,7 @@ def serialize_entity(entity: BaseModel) -> dict:
     data = entity.model_dump(
         mode="json",
         exclude=SERIALIZATION_EXCLUDE_KEYS,
-        exclude_none=True,
+        exclude_none=False,
     )
     processed = _convert_identifiables_to_ids(data)
     return processed


### PR DESCRIPTION
I was too eager to drop the None entries from payload. For this to work we need to set all optionals to None on server side.

I revert for now so that optional fields can be set to None and server doesn't throw missing validation errors left and right.