### PR TITLE
Simplify token usage

### DIFF
--- a/examples/01_searching.ipynb
+++ b/examples/01_searching.ipynb
@@ -28,8 +28,9 @@
     "    virtual_lab_id=\"a98b7abc-fc46-4700-9e3d-37137812c730\",\n",
     "    project_id=\"0dbced5f-cc3d-488a-8c7f-cfb8ea039dc6\",\n",
     ")\n",
-    "client = Client(api_url=entitycore_api_url, project_context=project_context)\n",
     "token = os.getenv(\"ACCESS_TOKEN\", \"XXX\")\n",
+    "client = Client(api_url=entitycore_api_url, project_context=project_context, token_manager=token)\n",
+    "\n",
     "\n",
     "# uncomment for staging\n",
     "# from obi_auth import get_token\n",
@@ -53,7 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "all_species = client.search_entity(entity_type=Species, token=token).all()"
+    "all_species = client.search_entity(entity_type=Species).all()"
    ]
   },
   {
@@ -82,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "all_strains = client.search_entity(entity_type=Strain, token=token).all()"
+    "all_strains = client.search_entity(entity_type=Strain).all()"
    ]
   },
   {
@@ -111,7 +112,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "all_roles = client.search_entity(entity_type=Role, token=token).all()"
+    "all_roles = client.search_entity(entity_type=Role).all()"
    ]
   },
   {
@@ -140,7 +141,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "all_users = client.search_entity(entity_type=Person, token=token).all()"
+    "all_users = client.search_entity(entity_type=Person).all()"
    ]
   },
   {
@@ -169,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "all_orgs = client.search_entity(entity_type=Organization, token=token).all()"
+    "all_orgs = client.search_entity(entity_type=Organization).all()"
    ]
   },
   {
@@ -198,7 +199,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "all_mtypes = client.search_entity(entity_type=MTypeClass, token=token).all()"
+    "all_mtypes = client.search_entity(entity_type=MTypeClass).all()"
    ]
   },
   {
@@ -227,7 +228,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "morphs = client.search_entity(entity_type=ReconstructionMorphology, token=token, limit=10).all()"
+    "morphs = client.search_entity(entity_type=ReconstructionMorphology, limit=10).all()"
    ]
   },
   {
@@ -257,7 +258,7 @@
    "outputs": [],
    "source": [
     "morphs = client.search_entity(\n",
-    "    entity_type=ReconstructionMorphology, query={\"mtype__pref_label\": \"SR_PC\"}, token=token\n",
+    "    entity_type=ReconstructionMorphology, query={\"mtype__pref_label\": \"SR_PC\"}\n",
     ").all()"
    ]
   },
@@ -271,6 +272,14 @@
     "rprint(len(morphs))\n",
     "rprint(morphs[:2])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c41d5ae-81a6-4b01-965c-3f46a082cd31",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/02_morphology.ipynb
+++ b/examples/02_morphology.ipynb
@@ -72,9 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "species = client.search_entity(\n",
-    "    entity_type=Species, query={\"name\": \"Mus musculus\"}, limit=10\n",
-    ").one()"
+    "species = client.search_entity(entity_type=Species, query={\"name\": \"Mus musculus\"}, limit=10).one()"
    ]
   },
   {
@@ -165,9 +163,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "brain_region = client.search_entity(\n",
-    "    entity_type=BrainRegion, query={\"annotation_value\": 68}\n",
-    ").one()"
+    "brain_region = client.search_entity(entity_type=BrainRegion, query={\"annotation_value\": 68}).one()"
    ]
   },
   {
@@ -393,9 +389,7 @@
    ],
    "source": [
     "# with assets included (default)\n",
-    "fetched = client.get_entity(\n",
-    "    entity_id=registered.id, entity_type=ReconstructionMorphology\n",
-    ")"
+    "fetched = client.get_entity(entity_id=registered.id, entity_type=ReconstructionMorphology)"
    ]
   },
   {

--- a/examples/02_morphology.ipynb
+++ b/examples/02_morphology.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "47471adc-9c79-4262-9fc4-66f5579f14a8",
    "metadata": {},
    "outputs": [],
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "5e4f4ff2-3d5b-4f3a-90a9-ea43d587ebce",
    "metadata": {},
    "outputs": [],
@@ -45,8 +45,9 @@
     "    virtual_lab_id=\"a98b7abc-fc46-4700-9e3d-37137812c730\",\n",
     "    project_id=\"0dbced5f-cc3d-488a-8c7f-cfb8ea039dc6\",\n",
     ")\n",
-    "client = Client(api_url=entitycore_api_url, project_context=project_context)\n",
     "token = os.getenv(\"ACCESS_TOKEN\", \"XXX\")\n",
+    "client = Client(api_url=entitycore_api_url, project_context=project_context, token_manager=token)\n",
+    "\n",
     "\n",
     "# uncomment for staging\n",
     "# from obi_auth import get_token\n",
@@ -66,64 +67,149 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "93d30bc5-c40c-4a5d-ad9e-9b0c4abc3ef4",
    "metadata": {},
    "outputs": [],
    "source": [
     "species = client.search_entity(\n",
-    "    entity_type=Species, query={\"name\": \"Mus musculus\"}, token=token, limit=10\n",
+    "    entity_type=Species, query={\"name\": \"Mus musculus\"}, limit=10\n",
     ").one()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "2a697b1d-2bdc-488d-8ce6-5f7547af87fe",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Species</span><span style=\"font-weight: bold\">(</span>\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">id</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">UUID</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008000; text-decoration-color: #008000\">'fbb190bf-593a-4a89-bd81-fcb6e4c5c133'</span><span style=\"font-weight: bold\">)</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">update_date</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">datetime</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">.datetime</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2025</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">6</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">11</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">12</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">51</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">883561</span>, <span style=\"color: #808000; text-decoration-color: #808000\">tzinfo</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">TzInfo</span><span style=\"font-weight: bold\">(</span>UTC<span style=\"font-weight: bold\">))</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">creation_date</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">datetime</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">.datetime</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2025</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">6</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">11</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">12</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">51</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">883561</span>, <span style=\"color: #808000; text-decoration-color: #808000\">tzinfo</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">TzInfo</span><span style=\"font-weight: bold\">(</span>UTC<span style=\"font-weight: bold\">))</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">name</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Mus musculus'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">taxonomy_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'NCBITaxon:10090'</span>\n",
+       "<span style=\"font-weight: bold\">)</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1;35mSpecies\u001b[0m\u001b[1m(\u001b[0m\n",
+       "    \u001b[33mid\u001b[0m=\u001b[1;35mUUID\u001b[0m\u001b[1m(\u001b[0m\u001b[32m'fbb190bf-593a-4a89-bd81-fcb6e4c5c133'\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "    \u001b[33mupdate_date\u001b[0m=\u001b[1;35mdatetime\u001b[0m\u001b[1;35m.datetime\u001b[0m\u001b[1m(\u001b[0m\u001b[1;36m2025\u001b[0m, \u001b[1;36m6\u001b[0m, \u001b[1;36m11\u001b[0m, \u001b[1;36m7\u001b[0m, \u001b[1;36m12\u001b[0m, \u001b[1;36m51\u001b[0m, \u001b[1;36m883561\u001b[0m, \u001b[33mtzinfo\u001b[0m=\u001b[1;35mTzInfo\u001b[0m\u001b[1m(\u001b[0mUTC\u001b[1m)\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "    \u001b[33mcreation_date\u001b[0m=\u001b[1;35mdatetime\u001b[0m\u001b[1;35m.datetime\u001b[0m\u001b[1m(\u001b[0m\u001b[1;36m2025\u001b[0m, \u001b[1;36m6\u001b[0m, \u001b[1;36m11\u001b[0m, \u001b[1;36m7\u001b[0m, \u001b[1;36m12\u001b[0m, \u001b[1;36m51\u001b[0m, \u001b[1;36m883561\u001b[0m, \u001b[33mtzinfo\u001b[0m=\u001b[1;35mTzInfo\u001b[0m\u001b[1m(\u001b[0mUTC\u001b[1m)\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "    \u001b[33mname\u001b[0m=\u001b[32m'Mus musculus'\u001b[0m,\n",
+       "    \u001b[33mtaxonomy_id\u001b[0m=\u001b[32m'NCBITaxon:10090'\u001b[0m\n",
+       "\u001b[1m)\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "rprint(species)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "0ea7fd15-bf51-4039-a1fd-c580ce813ff3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "IteratorResultError",
+     "evalue": "Iterable is empty.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mIteratorResultError\u001b[39m                       Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[22]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m strain = \u001b[43mclient\u001b[49m\u001b[43m.\u001b[49m\u001b[43msearch_entity\u001b[49m\u001b[43m(\u001b[49m\u001b[43mentity_type\u001b[49m\u001b[43m=\u001b[49m\u001b[43mStrain\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mquery\u001b[49m\u001b[43m=\u001b[49m\u001b[43m{\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mname\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mCux2-CreERT2\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\u001b[43m.\u001b[49m\u001b[43mone\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/Projects/entitysdk/src/entitysdk/result.py:33\u001b[39m, in \u001b[36mIteratorResult.one\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m     31\u001b[39m \u001b[38;5;250m\u001b[39m\u001b[33;03m\"\"\"Return exactly one item from the iterable or raise an error if not exactly one item.\"\"\"\u001b[39;00m\n\u001b[32m     32\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m (first_item := \u001b[38;5;28mself\u001b[39m.first()) \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m33\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m IteratorResultError(\u001b[33m\"\u001b[39m\u001b[33mIterable is empty.\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m     34\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mnext\u001b[39m(\u001b[38;5;28mself\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m) \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m     35\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m first_item\n",
+      "\u001b[31mIteratorResultError\u001b[39m: Iterable is empty."
+     ]
+    }
+   ],
    "source": [
-    "strain = client.search_entity(entity_type=Strain, query={\"name\": \"Cux2-CreERT2\"}, token=token).one()"
+    "strain = client.search_entity(entity_type=Strain, query={\"name\": \"Cux2-CreERT2\"}).one()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "e5dde536-0c58-4d42-a834-1b1a0ec17e9d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'strain' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[23]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m rprint(\u001b[43mstrain\u001b[49m)\n",
+      "\u001b[31mNameError\u001b[39m: name 'strain' is not defined"
+     ]
+    }
+   ],
    "source": [
     "rprint(strain)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "5d42a174-9737-4477-830a-3dc908dea925",
    "metadata": {},
    "outputs": [],
    "source": [
     "brain_region = client.search_entity(\n",
-    "    entity_type=BrainRegion, query={\"annotation_value\": 68}, token=token\n",
+    "    entity_type=BrainRegion, query={\"annotation_value\": 68}\n",
     ").one()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "282200cd-ad0c-4bb3-bc21-88de85289179",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">BrainRegion</span><span style=\"font-weight: bold\">(</span>\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">id</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">UUID</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008000; text-decoration-color: #008000\">'ef1772f4-100c-4e80-a132-3c2481b377bd'</span><span style=\"font-weight: bold\">)</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">update_date</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">datetime</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">.datetime</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2025</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">6</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">11</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">12</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">37</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">910887</span>, <span style=\"color: #808000; text-decoration-color: #808000\">tzinfo</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">TzInfo</span><span style=\"font-weight: bold\">(</span>UTC<span style=\"font-weight: bold\">))</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">creation_date</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">datetime</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">.datetime</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2025</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">6</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">11</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">12</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">37</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">910887</span>, <span style=\"color: #808000; text-decoration-color: #808000\">tzinfo</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">TzInfo</span><span style=\"font-weight: bold\">(</span>UTC<span style=\"font-weight: bold\">))</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">name</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Frontal pole, layer 1'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">annotation_value</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">68</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">acronym</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'FRP1'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">parent_structure_id</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">UUID</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008000; text-decoration-color: #008000\">'ec1ca538-d956-4c07-aa9b-e4ddf0b0bed8'</span><span style=\"font-weight: bold\">)</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">hierarchy_id</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">UUID</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008000; text-decoration-color: #008000\">'f728b4fa-4248-4e3a-8a5d-2f346baa9455'</span><span style=\"font-weight: bold\">)</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">color_hex_triplet</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'268F45'</span>\n",
+       "<span style=\"font-weight: bold\">)</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1;35mBrainRegion\u001b[0m\u001b[1m(\u001b[0m\n",
+       "    \u001b[33mid\u001b[0m=\u001b[1;35mUUID\u001b[0m\u001b[1m(\u001b[0m\u001b[32m'ef1772f4-100c-4e80-a132-3c2481b377bd'\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "    \u001b[33mupdate_date\u001b[0m=\u001b[1;35mdatetime\u001b[0m\u001b[1;35m.datetime\u001b[0m\u001b[1m(\u001b[0m\u001b[1;36m2025\u001b[0m, \u001b[1;36m6\u001b[0m, \u001b[1;36m11\u001b[0m, \u001b[1;36m7\u001b[0m, \u001b[1;36m12\u001b[0m, \u001b[1;36m37\u001b[0m, \u001b[1;36m910887\u001b[0m, \u001b[33mtzinfo\u001b[0m=\u001b[1;35mTzInfo\u001b[0m\u001b[1m(\u001b[0mUTC\u001b[1m)\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "    \u001b[33mcreation_date\u001b[0m=\u001b[1;35mdatetime\u001b[0m\u001b[1;35m.datetime\u001b[0m\u001b[1m(\u001b[0m\u001b[1;36m2025\u001b[0m, \u001b[1;36m6\u001b[0m, \u001b[1;36m11\u001b[0m, \u001b[1;36m7\u001b[0m, \u001b[1;36m12\u001b[0m, \u001b[1;36m37\u001b[0m, \u001b[1;36m910887\u001b[0m, \u001b[33mtzinfo\u001b[0m=\u001b[1;35mTzInfo\u001b[0m\u001b[1m(\u001b[0mUTC\u001b[1m)\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "    \u001b[33mname\u001b[0m=\u001b[32m'Frontal pole, layer 1'\u001b[0m,\n",
+       "    \u001b[33mannotation_value\u001b[0m=\u001b[1;36m68\u001b[0m,\n",
+       "    \u001b[33macronym\u001b[0m=\u001b[32m'FRP1'\u001b[0m,\n",
+       "    \u001b[33mparent_structure_id\u001b[0m=\u001b[1;35mUUID\u001b[0m\u001b[1m(\u001b[0m\u001b[32m'ec1ca538-d956-4c07-aa9b-e4ddf0b0bed8'\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "    \u001b[33mhierarchy_id\u001b[0m=\u001b[1;35mUUID\u001b[0m\u001b[1m(\u001b[0m\u001b[32m'f728b4fa-4248-4e3a-8a5d-2f346baa9455'\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "    \u001b[33mcolor_hex_triplet\u001b[0m=\u001b[32m'268F45'\u001b[0m\n",
+       "\u001b[1m)\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "rprint(brain_region)"
    ]
@@ -138,10 +224,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "fdc328df-2cef-4e23-b240-2de061f0e640",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'strain' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[26]\u001b[39m\u001b[32m, line 10\u001b[39m\n\u001b[32m      1\u001b[39m brain_location = BrainLocation(\n\u001b[32m      2\u001b[39m     x=\u001b[32m4101.52490234375\u001b[39m,\n\u001b[32m      3\u001b[39m     y=\u001b[32m1173.8499755859375\u001b[39m,\n\u001b[32m      4\u001b[39m     z=\u001b[32m4744.60009765625\u001b[39m,\n\u001b[32m      5\u001b[39m )\n\u001b[32m      6\u001b[39m morphology = ReconstructionMorphology(\n\u001b[32m      7\u001b[39m     name=\u001b[33m\"\u001b[39m\u001b[33mmy-morph\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m      8\u001b[39m     description=\u001b[33m\"\u001b[39m\u001b[33mA morphology\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m      9\u001b[39m     species=species,\n\u001b[32m---> \u001b[39m\u001b[32m10\u001b[39m     strain=\u001b[43mstrain\u001b[49m,\n\u001b[32m     11\u001b[39m     brain_region=brain_region,\n\u001b[32m     12\u001b[39m     location=brain_location,\n\u001b[32m     13\u001b[39m     legacy_id=\u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[32m     14\u001b[39m )\n",
+      "\u001b[31mNameError\u001b[39m: name 'strain' is not defined"
+     ]
+    }
+   ],
    "source": [
     "brain_location = BrainLocation(\n",
     "    x=4101.52490234375,\n",
@@ -161,10 +259,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "2568abc1-8b72-4f35-85d3-19f6935ea232",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'morphology' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[27]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m rprint(\u001b[43mmorphology\u001b[49m)\n",
+      "\u001b[31mNameError\u001b[39m: name 'morphology' is not defined"
+     ]
+    }
+   ],
    "source": [
     "rprint(morphology)"
    ]
@@ -179,12 +289,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "2e32a168",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'morphology' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[28]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m registered = client.register_entity(entity=\u001b[43mmorphology\u001b[49m)\n",
+      "\u001b[31mNameError\u001b[39m: name 'morphology' is not defined"
+     ]
+    }
+   ],
    "source": [
-    "registered = client.register_entity(entity=morphology, token=token)"
+    "registered = client.register_entity(entity=morphology)"
    ]
   },
   {
@@ -197,10 +319,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "51d0c5b4-6251-4ee4-99ef-b6449a4d5da8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'registered' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[29]\u001b[39m\u001b[32m, line 10\u001b[39m\n\u001b[32m      6\u001b[39m file2.write_text(\u001b[33m\"\u001b[39m\u001b[33mswc\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m      8\u001b[39m \u001b[38;5;66;03m# use a filepath to register first asset\u001b[39;00m\n\u001b[32m      9\u001b[39m asset1 = client.upload_file(\n\u001b[32m---> \u001b[39m\u001b[32m10\u001b[39m     entity_id=\u001b[43mregistered\u001b[49m.id,\n\u001b[32m     11\u001b[39m     entity_type=ReconstructionMorphology,\n\u001b[32m     12\u001b[39m     file_path=file1,\n\u001b[32m     13\u001b[39m     file_content_type=\u001b[33m\"\u001b[39m\u001b[33mapplication/h5\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     14\u001b[39m )\n\u001b[32m     15\u001b[39m rprint(asset1)\n\u001b[32m     17\u001b[39m \u001b[38;5;66;03m# use an in-memory buffer to upload second asset\u001b[39;00m\n",
+      "\u001b[31mNameError\u001b[39m: name 'registered' is not defined"
+     ]
+    }
+   ],
    "source": [
     "with tempfile.TemporaryDirectory() as tdir:\n",
     "    file1 = Path(tdir, \"morph.h5\")\n",
@@ -215,7 +349,6 @@
     "        entity_type=ReconstructionMorphology,\n",
     "        file_path=file1,\n",
     "        file_content_type=\"application/h5\",\n",
-    "        token=token,\n",
     "    )\n",
     "    rprint(asset1)\n",
     "\n",
@@ -228,7 +361,6 @@
     "        file_content=buffer,\n",
     "        file_name=\"buffer.h5\",\n",
     "        file_content_type=\"application/swc\",\n",
-    "        token=token,\n",
     "    )\n",
     "    rprint(asset2)"
    ]
@@ -243,14 +375,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "3a0f9360-a805-4ccf-ad7c-95f7237d0819",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'registered' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[12]\u001b[39m\u001b[32m, line 3\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# with assets included (default)\u001b[39;00m\n\u001b[32m      2\u001b[39m fetched = client.get_entity(\n\u001b[32m----> \u001b[39m\u001b[32m3\u001b[39m     entity_id=\u001b[43mregistered\u001b[49m.id, entity_type=ReconstructionMorphology\n\u001b[32m      4\u001b[39m )\n",
+      "\u001b[31mNameError\u001b[39m: name 'registered' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# with assets included (default)\n",
     "fetched = client.get_entity(\n",
-    "    entity_id=registered.id, entity_type=ReconstructionMorphology, token=token\n",
+    "    entity_id=registered.id, entity_type=ReconstructionMorphology\n",
     ")"
    ]
   },
@@ -266,14 +410,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "c979f2e6-5c6c-426e-9828-9202f8c63508",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'registered' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[15]\u001b[39m\u001b[32m, line 3\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# without assets\u001b[39;00m\n\u001b[32m      2\u001b[39m fetched_wout_assets = client.get_entity(\n\u001b[32m----> \u001b[39m\u001b[32m3\u001b[39m     entity_id=\u001b[43mregistered\u001b[49m.id, entity_type=ReconstructionMorphology, with_assets=\u001b[38;5;28;01mFalse\u001b[39;00m\n\u001b[32m      4\u001b[39m )\n",
+      "\u001b[31mNameError\u001b[39m: name 'registered' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# without assets\n",
     "fetched_wout_assets = client.get_entity(\n",
-    "    entity_id=registered.id, entity_type=ReconstructionMorphology, token=token, with_assets=False\n",
+    "    entity_id=registered.id, entity_type=ReconstructionMorphology, with_assets=False\n",
     ")"
    ]
   },
@@ -306,11 +462,10 @@
     "    fetched.assets,\n",
     "    selection={\"content_type\": \"application/swc\"},\n",
     "    output_path=\"./my-file.h5\",\n",
-    "    token=token,\n",
     ").one()\n",
     "\n",
     "content = client.download_content(\n",
-    "    entity_id=fetched.id, entity_type=type(fetched), asset_id=downloaded_asset.id, token=token\n",
+    "    entity_id=fetched.id, entity_type=type(fetched), asset_id=downloaded_asset.id\n",
     ")\n",
     "\n",
     "print(content)\n",
@@ -327,10 +482,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "9a211674-54d2-498f-983a-ab3f3675087d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'fetched' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[16]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m asset \u001b[38;5;129;01min\u001b[39;00m \u001b[43mfetched\u001b[49m.assets:\n\u001b[32m      2\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m asset.content_type == \u001b[33m\"\u001b[39m\u001b[33mapplication/swc\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m      3\u001b[39m         \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[33mDeleting asset \u001b[39m\u001b[33m\"\u001b[39m, asset.id)\n",
+      "\u001b[31mNameError\u001b[39m: name 'fetched' is not defined"
+     ]
+    }
+   ],
    "source": [
     "for asset in fetched.assets:\n",
     "    if asset.content_type == \"application/swc\":\n",
@@ -339,7 +506,6 @@
     "            entity_id=fetched.id,\n",
     "            entity_type=type(registered),\n",
     "            asset_id=asset.id,\n",
-    "            token=token,\n",
     "        )\n",
     "        break\n",
     "\n",
@@ -361,10 +527,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "69d44c3c-b07c-46d2-978f-98b1b80b5212",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'fetched' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[17]\u001b[39m\u001b[32m, line 7\u001b[39m\n\u001b[32m      4\u001b[39m file1.write_text(\u001b[33m\"\u001b[39m\u001b[33mupdated h5\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m      5\u001b[39m file1.touch()\n\u001b[32m----> \u001b[39m\u001b[32m7\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m asset \u001b[38;5;129;01min\u001b[39;00m \u001b[43mfetched\u001b[49m.assets:\n\u001b[32m      8\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m asset.content_type == \u001b[33m\"\u001b[39m\u001b[33mapplication/h5\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m      9\u001b[39m         updated_asset = client.update_asset_file(\n\u001b[32m     10\u001b[39m             entity_id=fetched.id,\n\u001b[32m     11\u001b[39m             entity_type=\u001b[38;5;28mtype\u001b[39m(registered),\n\u001b[32m   (...)\u001b[39m\u001b[32m     15\u001b[39m             file_content_type=asset.content_type,\n\u001b[32m     16\u001b[39m         )\n",
+      "\u001b[31mNameError\u001b[39m: name 'fetched' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# update h5 asset with another file\n",
     "with tempfile.TemporaryDirectory() as tdir:\n",
@@ -381,7 +559,6 @@
     "                file_name=asset1.path,\n",
     "                file_path=file1,\n",
     "                file_content_type=asset.content_type,\n",
-    "                token=token,\n",
     "            )\n",
     "            break\n",
     "\n",
@@ -428,7 +605,6 @@
     "hits = client.search_entity(\n",
     "    entity_type=ReconstructionMorphology,\n",
     "    query={\"name__ilike\": \"my-morph\", \"page\": 1, \"page_size\": 2},\n",
-    "    token=token,\n",
     "    limit=None,\n",
     ").all()\n",
     "\n",

--- a/examples/03_contribution.ipynb
+++ b/examples/03_contribution.ipynb
@@ -20,8 +20,9 @@
     "    virtual_lab_id=\"a98b7abc-fc46-4700-9e3d-37137812c730\",\n",
     "    project_id=\"0dbced5f-cc3d-488a-8c7f-cfb8ea039dc6\",\n",
     ")\n",
-    "client = Client(api_url=entitycore_api_url, project_context=project_context)\n",
     "token = os.getenv(\"ACCESS_TOKEN\", \"XXX\")\n",
+    "client = Client(api_url=entitycore_api_url, project_context=project_context, token_manager=token)\n",
+    "\n",
     "\n",
     "# uncomment for staging\n",
     "# from obi_auth import get_token\n",
@@ -46,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = client.search_entity(entity_type=Organization, token=token, limit=1).one()"
+    "agent = client.search_entity(entity_type=Organization, limit=1).one()"
    ]
   },
   {
@@ -66,7 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "role = client.search_entity(entity_type=Role, token=token, limit=1).one()"
+    "role = client.search_entity(entity_type=Role, limit=1).one()"
    ]
   },
   {
@@ -87,7 +88,7 @@
    "outputs": [],
    "source": [
     "morphology = client.search_entity(\n",
-    "    entity_type=ReconstructionMorphology, token=token, limit=1, query={\"name__ilike\": \"my-morph\"}\n",
+    "    entity_type=ReconstructionMorphology, limit=1, query={\"name__ilike\": \"my-morph\"}\n",
     ").first()"
    ]
   },
@@ -142,7 +143,7 @@
    "source": [
     "# Note: It will fail if registered twice\n",
     "# because there is a uniqueness constraint on (agent, morphology_id)\n",
-    "registered = client.register_entity(entity=contribution, token=token)"
+    "registered = client.register_entity(entity=contribution)"
    ]
   },
   {
@@ -170,7 +171,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "retrieved = client.get_entity(entity_type=Contribution, entity_id=registered.id, token=token)"
+    "retrieved = client.get_entity(entity_type=Contribution, entity_id=registered.id)"
    ]
   },
   {

--- a/examples/04_circuit.ipynb
+++ b/examples/04_circuit.ipynb
@@ -63,9 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "brain_region = client.search_entity(\n",
-    "    entity_type=models.BrainRegion, query={\"acronym\": \"CB\"}\n",
-    ").first()\n",
+    "brain_region = client.search_entity(entity_type=models.BrainRegion, query={\"acronym\": \"CB\"}).first()\n",
     "\n",
     "\n",
     "circuit = models.Circuit(\n",
@@ -124,9 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fetched = client.get_entity(\n",
-    "    entity_id=registered_circuit.id, entity_type=models.Circuit\n",
-    ")"
+    "fetched = client.get_entity(entity_id=registered_circuit.id, entity_type=models.Circuit)"
    ]
   },
   {

--- a/examples/04_circuit.ipynb
+++ b/examples/04_circuit.ipynb
@@ -18,8 +18,8 @@
     "    virtual_lab_id=\"a98b7abc-fc46-4700-9e3d-37137812c730\",\n",
     "    project_id=\"0dbced5f-cc3d-488a-8c7f-cfb8ea039dc6\",\n",
     ")\n",
-    "client = Client(api_url=entitycore_api_url, project_context=project_context)\n",
-    "token = os.getenv(\"ACCESS_TOKEN\", \"XXX\")"
+    "token = os.getenv(\"ACCESS_TOKEN\", \"XXX\")\n",
+    "client = Client(api_url=entitycore_api_url, project_context=project_context, token_manager=token)"
    ]
   },
   {
@@ -38,14 +38,14 @@
    "outputs": [],
    "source": [
     "species = client.search_entity(\n",
-    "    entity_type=models.Species, token=token, query={\"name__ilike\": \"Mus musculus\"}\n",
+    "    entity_type=models.Species, query={\"name__ilike\": \"Mus musculus\"}\n",
     ").first()\n",
     "\n",
     "subject = models.Subject(\n",
     "    name=\"my-subject\", description=\"my-subject-description\", sex=\"male\", species=species\n",
     ")\n",
     "\n",
-    "subject = client.register_entity(subject, token=token)"
+    "subject = client.register_entity(subject)"
    ]
   },
   {
@@ -64,7 +64,7 @@
    "outputs": [],
    "source": [
     "brain_region = client.search_entity(\n",
-    "    entity_type=models.BrainRegion, token=token, query={\"acronym\": \"CB\"}\n",
+    "    entity_type=models.BrainRegion, query={\"acronym\": \"CB\"}\n",
     ").first()\n",
     "\n",
     "\n",
@@ -96,7 +96,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "registered_circuit = client.register_entity(circuit, token=token)"
+    "registered_circuit = client.register_entity(circuit)"
    ]
   },
   {
@@ -125,7 +125,7 @@
    "outputs": [],
    "source": [
     "fetched = client.get_entity(\n",
-    "    entity_id=registered_circuit.id, entity_type=models.Circuit, token=token\n",
+    "    entity_id=registered_circuit.id, entity_type=models.Circuit\n",
     ")"
    ]
   },
@@ -138,6 +138,14 @@
    "source": [
     "rprint(fetched)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f359b797-02ad-4358-bef7-ad3f3008d323",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/entitysdk/token_manager.py
+++ b/src/entitysdk/token_manager.py
@@ -1,9 +1,11 @@
 """Token manager module."""
 
 import os
+from collections.abc import Callable
 from typing import Protocol
 
 from entitysdk.exception import EntitySDKError
+from entitysdk.types import Token
 
 
 class TokenManager(Protocol):
@@ -20,7 +22,7 @@ class TokenFromEnv:
         """Initialize token manager with an environment variable name."""
         self._env_var_name = env_var_name
 
-    def get_token(self) -> str:
+    def get_token(self) -> Token:
         """Get the token from the environment variable."""
         try:
             return os.environ[self._env_var_name]
@@ -28,3 +30,27 @@ class TokenFromEnv:
             raise EntitySDKError(
                 f"Environment variable '{self._env_var_name}' not found."
             ) from None
+
+
+class TokenFromValue:
+    """Token manager that uses a fixed value as a token."""
+
+    def __init__(self, value: Token) -> None:
+        """Initialize token manager with a fixed value."""
+        self._value = value
+
+    def get_token(self) -> Token:
+        """Get the token from the stored variable."""
+        return self._value
+
+
+class TokenFromFunction:
+    """Token manager that calls a function to get a token."""
+
+    def __init__(self, function: Callable[[], Token]) -> None:
+        """Initialize token manager with a function to call later."""
+        self._function = function
+
+    def get_token(self) -> Token:
+        """Get the token by calling the function."""
+        return self._function()

--- a/src/entitysdk/types.py
+++ b/src/entitysdk/types.py
@@ -4,6 +4,7 @@ import uuid
 from enum import StrEnum, auto
 
 ID = uuid.UUID
+Token = str
 
 
 class DeploymentEnvironment(StrEnum):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -42,8 +42,8 @@ def request_headers_no_context(auth_token):
 
 
 @pytest.fixture
-def client(project_context, api_url):
-    return Client(api_url=api_url, project_context=project_context)
+def client(project_context, api_url, auth_token):
+    return Client(api_url=api_url, project_context=project_context, token_manager=auth_token)
 
 
 @pytest.fixture

--- a/tests/unit/models/data/circuit.json
+++ b/tests/unit/models/data/circuit.json
@@ -32,7 +32,7 @@
   "contact_id": null,
   "atlas_id": null,
   "subject": {
-    "assets": null,
+    "assets": [],
     "id": "5a567dde-8ce5-40d2-8619-d6f40c76aef6",
     "update_date": null,
     "creation_date": null,

--- a/tests/unit/models/test_circuit.py
+++ b/tests/unit/models/test_circuit.py
@@ -25,16 +25,14 @@ def test_read_circuit(client, httpx_mock, auth_token, json_data):
     entity = client.get_entity(
         entity_id=MOCK_UUID,
         entity_type=Circuit,
-        token=auth_token,
-        with_assets=False,
     )
     assert entity.model_dump(mode="json") == json_data | {"legacy_id": None}
 
 
-def test_register_circuit(client, httpx_mock, auth_token, circuit, json_data):
+def test_register_circuit(client, httpx_mock, circuit, json_data):
     httpx_mock.add_response(
         method="POST", json=circuit.model_dump(mode="json") | {"id": str(MOCK_UUID)}
     )
-    registered = client.register_entity(entity=circuit, token=auth_token)
+    registered = client.register_entity(entity=circuit)
     expected_json = json_data.copy() | {"id": str(MOCK_UUID)}
     assert registered.model_dump(mode="json") == expected_json | {"legacy_id": None}

--- a/tests/unit/models/test_electrical_cell_recording.py
+++ b/tests/unit/models/test_electrical_cell_recording.py
@@ -27,7 +27,6 @@ def test_read(client, httpx_mock, auth_token, json_data):
     entity = client.get_entity(
         entity_id=MOCK_UUID,
         entity_type=Model,
-        token=auth_token,
     )
     assert entity.model_dump(mode="json", exclude_none=True) == json_data
 
@@ -36,6 +35,6 @@ def test_register(client, httpx_mock, auth_token, model, json_data):
     httpx_mock.add_response(
         method="POST", json=model.model_dump(mode="json") | {"id": str(MOCK_UUID)}
     )
-    registered = client.register_entity(entity=model, token=auth_token)
+    registered = client.register_entity(entity=model)
     expected_json = json_data | {"id": str(MOCK_UUID)}
     assert registered.model_dump(mode="json", exclude_none=True) == expected_json

--- a/tests/unit/models/test_ion_channel_model.py
+++ b/tests/unit/models/test_ion_channel_model.py
@@ -25,7 +25,6 @@ def test_read_ion_channel_model(client, httpx_mock, auth_token, json_ion_channel
     entity = client.get_entity(
         entity_id=MOCK_UUID,
         entity_type=IonChannelModel,
-        token=auth_token,
     )
     assert entity.model_dump(mode="json") == json_ion_channel_expanded | {"legacy_id": None}
 
@@ -36,7 +35,7 @@ def test_register_ion_channel_model(
     httpx_mock.add_response(
         method="POST", json=ion_channel_model.model_dump(mode="json") | {"id": str(MOCK_UUID)}
     )
-    registered = client.register_entity(entity=ion_channel_model, token=auth_token)
+    registered = client.register_entity(entity=ion_channel_model)
     expected_json = json_ion_channel_expanded.copy() | {"id": str(MOCK_UUID)}
     assert registered.model_dump(mode="json") == expected_json | {"legacy_id": None}
 
@@ -52,7 +51,6 @@ def test_update_ion_channel_model(
         entity_id=ion_channel_model.id,
         entity_type=IonChannelModel,
         attrs_or_entity={"name": "foo"},
-        token=auth_token,
     )
 
     expected_json = json_ion_channel_expanded.copy() | {"name": "foo"}

--- a/tests/unit/models/test_memodel_calibration_result.py
+++ b/tests/unit/models/test_memodel_calibration_result.py
@@ -27,7 +27,6 @@ def test_read(client, httpx_mock, auth_token, json_data):
     entity = client.get_entity(
         entity_id=MOCK_UUID,
         entity_type=Model,
-        token=auth_token,
     )
     assert entity.model_dump(mode="json", exclude_none=True) == json_data
 
@@ -36,6 +35,6 @@ def test_register(client, httpx_mock, auth_token, model, json_data):
     httpx_mock.add_response(
         method="POST", json=model.model_dump(mode="json") | {"id": str(MOCK_UUID)}
     )
-    registered = client.register_entity(entity=model, token=auth_token)
+    registered = client.register_entity(entity=model)
     expected_json = json_data | {"id": str(MOCK_UUID)}
     assert registered.model_dump(mode="json", exclude_none=True) == expected_json

--- a/tests/unit/models/test_morphology.py
+++ b/tests/unit/models/test_morphology.py
@@ -27,7 +27,6 @@ def test_read_reconstruction_morphology(client, httpx_mock, auth_token, json_mor
     entity = client.get_entity(
         entity_id=MOCK_UUID,
         entity_type=ReconstructionMorphology,
-        token=auth_token,
     )
     assert entity.model_dump(mode="json") == json_morphology_expanded | {"legacy_id": None}
 
@@ -38,7 +37,7 @@ def test_register_reconstruction_morphology(
     httpx_mock.add_response(
         method="POST", json=morphology.model_dump(mode="json") | {"id": str(MOCK_UUID)}
     )
-    registered = client.register_entity(entity=morphology, token=auth_token)
+    registered = client.register_entity(entity=morphology)
     expected_json = json_morphology_expanded.copy() | {"id": str(MOCK_UUID)}
     assert registered.model_dump(mode="json") == expected_json | {"legacy_id": None}
 
@@ -54,7 +53,6 @@ def test_update_reconstruction_morphology(
         entity_id=morphology.id,
         entity_type=ReconstructionMorphology,
         attrs_or_entity={"name": "foo"},
-        token=auth_token,
     )
 
     expected_json = json_morphology_expanded.copy() | {"name": "foo"}

--- a/tests/unit/models/test_validation_result.py
+++ b/tests/unit/models/test_validation_result.py
@@ -27,7 +27,6 @@ def test_read(client, httpx_mock, auth_token, json_data):
     entity = client.get_entity(
         entity_id=MOCK_UUID,
         entity_type=Model,
-        token=auth_token,
     )
     assert entity.model_dump(mode="json", exclude_none=True) == json_data
 
@@ -36,6 +35,6 @@ def test_register(client, httpx_mock, auth_token, model, json_data):
     httpx_mock.add_response(
         method="POST", json=model.model_dump(mode="json") | {"id": str(MOCK_UUID)}
     )
-    registered = client.register_entity(entity=model, token=auth_token)
+    registered = client.register_entity(entity=model)
     expected_json = json_data | {"id": str(MOCK_UUID)}
     assert registered.model_dump(mode="json", exclude_none=True) == expected_json

--- a/tests/unit/test_token_manager.py
+++ b/tests/unit/test_token_manager.py
@@ -18,3 +18,13 @@ def test_token_from_env__raises():
 
     with pytest.raises(EntitySDKError, match="Environment variable 'TOKEN' not found."):
         token_manager.get_token()
+
+
+def test_TokenFromValue():
+    token_manager = test_module.TokenFromValue(value="foo")
+    assert token_manager.get_token() == "foo"
+
+
+def test_TokenFromFunction():
+    token_manager = test_module.TokenFromFunction(function=lambda: "foo")
+    assert token_manager.get_token() == "foo"


### PR DESCRIPTION
The token is removed from the methods of the client and is only handled at Client initialization.

If the token is passed as a fixed value:
```python
token = obi_auth.get_token()
client = Client(..., token_manager=token)
```
And it will by default create a TokenFromValue token manager to handle that fixed value.

This means however that it needs to be removed from the client methods as they no longer receive a token. For example.

```python
cient.get_entity(entity_id=entity_id, entity_type=Circuit)
```
instead of 
```python
cient.get_entity(entity_id=entity_id, entity_type=Circuit, token=token)
```

As this will affect many people I added them as reviewers.

Closes #66 