### PR TITLE
Correct content type for EModel hoc download

### DIFF
--- a/src/entitysdk/downloaders/emodel.py
+++ b/src/entitysdk/downloaders/emodel.py
@@ -22,7 +22,7 @@ def download_hoc(
     output_dir = create_dir(output_dir)
     asset = client.download_assets(
         emodel,
-        selection={"content_type": "application/x-neuron-hoc"},
+        selection={"content_type": "application/hoc"},
         output_path=output_dir,
     ).one()
 

--- a/tests/unit/downloaders/test_emodel.py
+++ b/tests/unit/downloaders/test_emodel.py
@@ -10,7 +10,7 @@ def _mock_asset_response(asset_id):
         "path": "foo.hoc",
         "full_path": "foo.hoc",
         "is_directory": False,
-        "content_type": "application/x-neuron-hoc",
+        "content_type": "application/hoc",
         "size": 100,
         "status": "created",
         "meta": {},

--- a/tests/unit/downloaders/test_memodel.py
+++ b/tests/unit/downloaders/test_memodel.py
@@ -45,7 +45,7 @@ def _mock_emodel_asset_response(asset_id):
         "path": "foo.hoc",
         "full_path": "foo.hoc",
         "is_directory": False,
-        "content_type": "application/x-neuron-hoc",
+        "content_type": "application/hoc",
         "size": 100,
         "status": "created",
         "meta": {},


### PR DESCRIPTION
This change is to align with the allowed content type for HOC files in entitycore.