### PR TITLE
Make subject/brain_region optional  for nested scientific artifact

### DIFF
--- a/src/entitysdk/models/scientific_artifact.py
+++ b/src/entitysdk/models/scientific_artifact.py
@@ -15,7 +15,7 @@ class ScientificArtifact(Entity):
     experiment_date: datetime | None = None
     contact_email: str | None = None
     atlas_id: ID | None = None
-    subject: Subject
-    brain_region: BrainRegion
+    subject: Subject | None = None
+    brain_region: BrainRegion | None = None
     license: License | None = None
     published_in: str | None = None


### PR DESCRIPTION
Nested scientific artifact does not return them, therefore they have to be optional to cover that case.