### PR TITLE
Make IonChannelModel inherit from ScientificArtifact

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "entitysdk"
 dependencies = [
     "httpx",
-    "pydantic",
+    "pydantic>=2.11",
     "pydantic-settings",
     "typing_extensions; python_version < '3.12'",
     "backports.strenum; python_version < '3.11'",

--- a/src/entitysdk/models/base.py
+++ b/src/entitysdk/models/base.py
@@ -18,6 +18,7 @@ class BaseModel(PydanticBaseModel):
         frozen=True,
         from_attributes=True,
         extra="ignore",
+        serialize_by_alias=True,
     )
 
     def evolve(self, **model_attributes) -> Self:

--- a/src/entitysdk/models/ion_channel_model.py
+++ b/src/entitysdk/models/ion_channel_model.py
@@ -6,8 +6,7 @@ from pydantic import Field
 
 from entitysdk.models.base import BaseModel
 from entitysdk.models.contribution import Contribution
-from entitysdk.models.entity import Entity
-from entitysdk.models.morphology import BrainRegion, License, Species, Strain
+from entitysdk.models.scientific_artifact import ScientificArtifact
 
 
 class UseIon(BaseModel):
@@ -17,35 +16,35 @@ class UseIon(BaseModel):
         str,
         Field(
             description="The name of the ion involved.",
-            examples="Ca",
+            examples=["Ca"],
         ),
     ]
     read: Annotated[
         list[str] | None,
         Field(
             description="Variables listed in the READ statement for this ion.",
-            examples=["eca", "ica"],
+            examples=[["eca", "ica"]],
         ),
     ]
     write: Annotated[
         list[str] | None,
         Field(
             description="Variables listed in the WRITE statement for this ion.",
-            examples=["ica"],
+            examples=[["ica"]],
         ),
     ]
     valence: Annotated[
         int | None,
         Field(
             description="VALENCE of the ion, if specified.",
-            examples=2,
+            examples=[2],
         ),
     ]
     main_ion: Annotated[
         bool | None,
         Field(
             description="Whether this ion is the main ion for the mechanism.",
-            examples=True,
+            examples=[True],
         ),
     ] = None
 
@@ -57,14 +56,15 @@ class NeuronBlock(BaseModel):
         list[dict[str, str | None]] | None,
         Field(
             description="Variables listed in the GLOBAL statement, with associated units.",
-            examples=[{"celsius": "degree C"}],
+            examples=[[{"celsius": "degree C"}]],
+            alias="global",
         ),
     ] = None
     range: Annotated[
         list[dict[str, str | None]] | None,
         Field(
             description="Variables listed in the RANGE statement, with associated units.",
-            examples=[{"gCa_HVAbar": "S/cm2"}, {"ica": "mA/cm2"}],
+            examples=[[{"gCa_HVAbar": "S/cm2"}, {"ica": "mA/cm2"}]],
         ),
     ] = None
     useion: Annotated[
@@ -77,12 +77,12 @@ class NeuronBlock(BaseModel):
         list[dict[str, str | None]] | None,
         Field(
             description="Variables listed in NONSPECIFIC_CURRENT statements.",
-            examples=[{"ihcn": "mA/cm2"}],
+            examples=[[{"ihcn": "mA/cm2"}]],
         ),
     ] = None
 
 
-class IonChannelModel(Entity):
+class IonChannelModel(ScientificArtifact):
     """Ion channel mechanism model."""
 
     name: Annotated[
@@ -90,39 +90,23 @@ class IonChannelModel(Entity):
         Field(
             description="The name of the ion channel model "
             "(e.g., the SUFFIX or POINT_PROCESS name).",
-            examples="Ca_HVA",
+            examples=["Ca_HVA"],
         ),
     ]
     nmodl_suffix: Annotated[
         str,
         Field(
             description="The SUFFIX of the ion channel model as defined in the NMODL file ",
-            examples="Ca_HVA",
+            examples=["Ca_HVA"],
         ),
     ]
     description: Annotated[
         str,
         Field(
             description="A description of the ion channel mechanism.",
-            examples="High-voltage activated calcium channel",
+            examples=["High-voltage activated calcium channel"],
         ),
     ]
-    species: Annotated[
-        Species,
-        Field(description="The species for which the mechanism applies."),
-    ]
-    strain: Annotated[
-        Strain | None,
-        Field(description="The specific strain of the species, if applicable."),
-    ] = None
-    brain_region: Annotated[
-        BrainRegion,
-        Field(description="The brain region where the mechanism is used or applies."),
-    ]
-    license: Annotated[
-        License | None,
-        Field(description="License under which the mechanism is distributed."),
-    ] = None
     contributions: Annotated[
         list[Contribution] | None,
         Field(description="List of contributions related to this mechanism."),

--- a/tests/unit/models/data/ion_channel_model.json
+++ b/tests/unit/models/data/ion_channel_model.json
@@ -1,96 +1,103 @@
 {
-  "id": "b8f38c7f-2675-4c6a-a394-f3a60a9a3e6f",
-  "type": "ion_channel_model",
-  "update_date": "2024-10-29T13:36:30.827776Z",
-  "creation_date": "2024-09-10T14:25:03.707956Z",
-  "created_by": null,
-  "updated_by": null,
-  "authorized_public": true,
-  "authorized_project_id": "c73ac3a5-3b7d-41bc-92e7-9f9309a49300",
-  "name": "Ca_HVA",
-  "nmodl_suffix": "Ca_HVA",
-  "brain_region": {
-    "id": "38553ac8-7d71-4591-bfee-2fc72e2dffdf",
-    "update_date": "2025-05-09T13:32:18.034672Z",
-    "creation_date": "2025-05-09T13:32:18.034672Z",
-    "name": "Accessory abducens nucleus",
-    "annotation_value": 568,
-    "acronym": "ACVI",
-    "parent_structure_id": "596305b3-71b2-41e4-afd3-b9f2e90f79f8",
-    "hierarchy_id": "e3e70682-c209-4cac-a29f-6fbed82c07cd",
-    "color_hex_triplet": "1000"
-  },
-  "description": "High-voltage activated calcium channel",
-  "species": {
-    "id": "0895fa61-fa6d-4674-9014-7300f9edf8da",
-    "update_date": "2025-03-29T16:48:36.175090Z",
-    "creation_date": "2025-03-29T16:48:36.175090Z",
-    "name": "Rattus norvegicus",
-    "taxonomy_id": "NCBITaxon:10116"
-  },
-  "strain": null,
-  "license": null,
-  "contributions": [
+  "contributions": [],
+  "assets": [
     {
-      "id": "7f43ce20-e63d-48c1-bc73-dabb38ee181b",
-      "update_date": "2025-03-29T16:49:12.449364Z",
-      "creation_date": "2025-03-29T16:49:12.449364Z",
-      "agent": {
-        "id": "f27cfa11-d1bc-4a14-b651-174bb53674ff",
-        "update_date": "2021-04-14T09:51:14.062000Z",
-        "creation_date": "2021-04-14T09:51:14.062000Z",
-        "type": "organization",
-        "pref_label": "École Polytechnique Fédérale de Lausanne",
-        "alternative_name": ""
-      },
-      "role": {
-        "id": "8b06e557-277b-4b0c-a439-bfb02d41927c",
-        "update_date": "2025-03-29T16:48:36.192831Z",
-        "creation_date": "2025-03-29T16:48:36.192831Z",
-        "name": "unspecified",
-        "role_id": "unspecified"
-      },
-      "entity": null
+      "size": 1188,
+      "sha256_digest": "e80d50df8f069863e4dd1f361a8a049933402ed233342f4ddaafab87064943fb",
+      "path": "Ca_HVA2.mod",
+      "full_path": "public/a98b7abc-fc46-4700-9e3d-37137812c730/0dbced5f-cc3d-488a-8c7f-cfb8ea039dc6/assets/ion_channel_model/21ebb7ab-b41b-441d-b494-6665075d26b0/Ca_HVA2.mod",
+      "is_directory": false,
+      "content_type": "application/mod",
+      "meta": {},
+      "label": "neuron_mechanisms",
+      "id": "73e5c7ef-5cb6-484d-b534-2c1209f9f280",
+      "status": "created"
     }
   ],
-  "is_ljp_corrected": false,
-  "is_temperature_dependent": true,
-  "temperature_celsius": 36,
-  "is_stochastic": true,
+  "license": null,
+  "creation_date": "2022-10-20T13:05:35.588000Z",
+  "update_date": "2025-04-15T12:41:30.454420Z",
+  "created_by": {
+    "id": "83844b40-ffa9-49f1-9c14-bc4a829e07b0",
+    "given_name": "Tanguy",
+    "family_name": "Damart",
+    "pref_label": "Tanguy Damart",
+    "type": "person"
+  },
+  "updated_by": {
+    "id": "59cc60b1-7604-44b4-a736-95c3e652c71a",
+    "given_name": "service-account-obp-singlecell-uploader-sa",
+    "family_name": "service-account-obp-singlecell-uploader-sa",
+    "pref_label": "service-account-obp-singlecell-uploader-sa service-account-obp-singlecell-uploader-sa",
+    "type": "person"
+  },
+  "brain_region": {
+    "creation_date": "2025-06-27T11:10:27.186088Z",
+    "update_date": "2025-06-27T11:10:27.186088Z",
+    "id": "4642cddb-4fbe-4aae-bbf7-0946d6ada066",
+    "annotation_value": 8,
+    "name": "Basic cell groups and regions",
+    "acronym": "grey",
+    "color_hex_triplet": "BFDAE3",
+    "parent_structure_id": "eb1167b3-67a9-4378-bc65-c1e582e2e662",
+    "hierarchy_id": "e3e70682-c209-4cac-a29f-6fbed82c07cd"
+  },
+  "subject": {
+    "id": "9edb44c6-33b5-403b-8ab6-0890cfb12d07",
+    "name": "Generic Mus musculus",
+    "description": "",
+    "sex": "unknown",
+    "weight": null,
+    "age_value": null,
+    "age_min": null,
+    "age_max": null,
+    "age_period": null,
+    "species": {
+      "id": "b7ad4cca-4ac2-4095-9781-37fb68fe9ca1",
+      "name": "Mus musculus",
+      "taxonomy_id": "NCBITaxon:10090"
+    }
+  },
+  "authorized_project_id": "0dbced5f-cc3d-488a-8c7f-cfb8ea039dc6",
+  "authorized_public": true,
+  "type": "ion_channel_model",
+  "id": "21ebb7ab-b41b-441d-b494-6665075d26b0",
+  "experiment_date": null,
+  "contact_email": null,
+  "published_in": null,
+  "description": "Ca_HVA2 Channel. Reuveni, Friedman, Amitai, and Gutnick, J.Neurosci. 1993, activation from Sayer, Schwindt and Crill (1990) inactivation from Dichter and Zona 1989. LJP: OK, inactivation corrected by 12.3 mV",
+  "name": "Ca_HVA2",
+  "nmodl_suffix": "Ca_HVA2",
+  "is_ljp_corrected": true,
+  "is_temperature_dependent": false,
+  "temperature_celsius": 34,
+  "is_stochastic": false,
   "neuron_block": {
-    "global_": [
-      {"gna": "S/cm2"},
-      {"gk": "S/cm2"}
-    ],
+    "global": [{"celsius": "degree C"}],
     "range": [
-      {"gCa_HVAbar": "S/cm2"},
-      {"ica": "mA/cm2"}
+      {
+        "gCa_HVAbar": "S/cm2"
+      },
+      {
+        "gCa_HVA": null
+      },
+      {
+        "ica": "mA/cm2"
+      }
     ],
     "useion": [
       {
-        "ion_name": "Ca",
-        "read": ["eca"],
-        "write": ["ica"],
-        "valence": 2,
+        "ion_name": "ca",
+        "read": [
+          "eca"
+        ],
+        "write": [
+          "ica"
+        ],
+        "valence": null,
         "main_ion": true
       }
     ],
-    "nonspecific": [{"ihcn": "mA/cm2"}]
-  },
-  "assets": [
-    {
-      "id": "a90bab5c-8529-4829-99fc-e90a270e8b30",
-      "path": "Ca_HVA.mod",
-      "full_path": "public/a98b7abc-fc46-4700-9e3d-37137812c730/0dbced5f-cc3d-488a-8c7f-cfb8ea039dc6/assets/ion_channel_model/9720aa4a-0cd1-4f10-b6ad-04deb8f997b6/Ca_HVA.mod",
-      "is_directory": false,
-      "content_type": "application/mod",
-      "label": "neuron_mechanisms",
-      "size": 561221,
-      "sha256_digest": "8b850eface3e7b881db62c361dc5da62be008ca81501c406a59646bf7075c95b",
-      "status": "created",
-      "creation_date": null,
-      "update_date": null,
-      "meta": {}
-    }
-  ]
+    "nonspecific": []
+  }
 }

--- a/tests/unit/models/test_ion_channel_model.py
+++ b/tests/unit/models/test_ion_channel_model.py
@@ -26,18 +26,16 @@ def test_read_ion_channel_model(client, httpx_mock, auth_token, json_ion_channel
         entity_id=MOCK_UUID,
         entity_type=IonChannelModel,
     )
-    assert entity.model_dump(mode="json") == json_ion_channel_expanded | {"legacy_id": None}
+    assert entity.model_dump(mode="json", exclude_unset=True) == json_ion_channel_expanded
 
 
 def test_register_ion_channel_model(
     client, httpx_mock, auth_token, ion_channel_model, json_ion_channel_expanded
 ):
-    httpx_mock.add_response(
-        method="POST", json=ion_channel_model.model_dump(mode="json") | {"id": str(MOCK_UUID)}
-    )
+    httpx_mock.add_response(method="POST", json=json_ion_channel_expanded | {"id": str(MOCK_UUID)})
     registered = client.register_entity(entity=ion_channel_model)
-    expected_json = json_ion_channel_expanded.copy() | {"id": str(MOCK_UUID)}
-    assert registered.model_dump(mode="json") == expected_json | {"legacy_id": None}
+    expected_json = json_ion_channel_expanded | {"id": str(MOCK_UUID)}
+    assert registered.model_dump(mode="json", exclude_unset=True) == expected_json
 
 
 def test_update_ion_channel_model(
@@ -45,7 +43,7 @@ def test_update_ion_channel_model(
 ):
     httpx_mock.add_response(
         method="PATCH",
-        json=ion_channel_model.model_dump(mode="json") | {"name": "foo"},
+        json=json_ion_channel_expanded | {"name": "foo"},
     )
     updated = client.update_entity(
         entity_id=ion_channel_model.id,
@@ -53,5 +51,5 @@ def test_update_ion_channel_model(
         attrs_or_entity={"name": "foo"},
     )
 
-    expected_json = json_ion_channel_expanded.copy() | {"name": "foo"}
-    assert updated.model_dump(mode="json") == expected_json | {"legacy_id": None}
+    expected_json = json_ion_channel_expanded | {"name": "foo"}
+    assert updated.model_dump(mode="json", exclude_unset=True) == expected_json


### PR DESCRIPTION
To be merged only after the deployment of https://github.com/openbraininstitute/entitycore/pull/300

It requires pydantic>=2.11 because of the new `serialize_by_alias`.
Previously, it was possible to specify a similar parameter in `model_dump()` only.
See https://pydantic.dev/articles/pydantic-v2-11-release

Minor: fixes examples as lists.