### PR TITLE
Downloaders

### DIFF
--- a/src/entitysdk/downloaders/memodel.py
+++ b/src/entitysdk/downloaders/memodel.py
@@ -7,6 +7,7 @@ from entitysdk.client import Client
 from entitysdk.downloaders.emodel import download_hoc
 from entitysdk.downloaders.ion_channel_model import download_ion_channel_mechanism
 from entitysdk.downloaders.morphology import download_morphology
+from entitysdk.exception import IteratorResultError
 from entitysdk.models.emodel import EModel
 from entitysdk.models.memodel import MEModel
 from entitysdk.schemas.memodel import DownloadedMEModel
@@ -30,9 +31,14 @@ def download_memodel(client: Client, memodel: MEModel, output_dir=".") -> Downlo
     hoc_path = download_hoc(client, emodel, Path(output_dir) / "hoc")
     # only take .asc format for now.
     # Will take specific format when morphology_format is integrated into MEModel
-    morphology_path = download_morphology(
-        client, memodel.morphology, Path(output_dir) / "morphology", "asc"
-    )
+    try:
+        morphology_path = download_morphology(
+            client, memodel.morphology, Path(output_dir) / "morphology", "asc"
+        )
+    except IteratorResultError:
+        morphology_path = download_morphology(
+            client, memodel.morphology, Path(output_dir) / "morphology", "swc"
+        )
     mechanisms_dir = create_dir(Path(output_dir) / "mechanisms")
     for ic in emodel.ion_channel_models or []:
         download_ion_channel_mechanism(client, ic, mechanisms_dir)


### PR DESCRIPTION
Some morphologies (eg. b48e86ce-bb8e-429d-8f95-e244b60cecf3) do not have any .asc file. For those, download the .swc file instead.