### PR TITLE
Add support for admin endpoints

### DIFF
--- a/src/entitysdk/models/__init__.py
+++ b/src/entitysdk/models/__init__.py
@@ -23,6 +23,7 @@ from entitysdk.models.ion_channel import IonChannel
 from entitysdk.models.ion_channel_model import IonChannelModel, NeuronBlock, UseIon
 from entitysdk.models.ion_channel_recording import IonChannelRecording
 from entitysdk.models.license import License
+from entitysdk.models.measurement_annotation import MeasurementAnnotation
 from entitysdk.models.memodel import MEModel
 from entitysdk.models.memodelcalibrationresult import MEModelCalibrationResult
 from entitysdk.models.mtype import MTypeClass
@@ -63,6 +64,7 @@ __all__ = [
     "IonChannelModel",
     "IonChannelRecording",
     "License",
+    "MeasurementAnnotation",
     "MEModel",
     "MEModelCalibrationResult",
     "MTypeClass",

--- a/src/entitysdk/models/measurement_annotation.py
+++ b/src/entitysdk/models/measurement_annotation.py
@@ -1,0 +1,35 @@
+"""Measurement annotation."""
+
+from entitysdk.models.base import BaseModel
+from entitysdk.models.core import Identifiable
+from entitysdk.types import (
+    ID,
+    MeasurableEntity,
+    MeasurementStatistic,
+    MeasurementUnit,
+    StructuralDomain,
+)
+
+
+class MeasurementItem(BaseModel):
+    """Measurement item."""
+
+    name: MeasurementStatistic | None
+    unit: MeasurementUnit | None
+    value: float | None
+
+
+class MeasurementKind(BaseModel):
+    """Measurement kind."""
+
+    structural_domain: StructuralDomain
+    measurement_items: list[MeasurementItem]
+    pref_label: str
+
+
+class MeasurementAnnotation(Identifiable):
+    """Measurement annotation."""
+
+    entity_id: ID
+    entity_type: MeasurableEntity
+    measurement_kinds: list[MeasurementKind]

--- a/src/entitysdk/route.py
+++ b/src/entitysdk/route.py
@@ -29,6 +29,7 @@ _ROUTES = {
     "IonChannelModel": "ion-channel-model",
     "IonChannelRecording": "ion-channel-recording",
     "License": "license",
+    "MeasurementAnnotation": "measurement-annotation",
     "MEModel": "memodel",
     "MEModelCalibrationResult": "memodel-calibration-result",
     "MTypeClassification": "mtype-classification",
@@ -79,9 +80,14 @@ def get_entities_endpoint(
     api_url: str,
     entity_type: type[Identifiable],
     entity_id: str | ID | None = None,
+    admin: bool = False,
 ) -> str:
     """Get the API endpoint for an entity type."""
     route_name = get_route_name(entity_type)
+
+    if admin:
+        route_name = f"admin/{route_name}"
+
     endpoint = route_name if entity_id is None else f"{route_name}/{entity_id}"
     return f"{api_url}/{endpoint}"
 
@@ -103,6 +109,7 @@ def get_assets_endpoint(
     entity_type: type[Identifiable],
     entity_id: str | ID,
     asset_id: str | ID | None = None,
+    admin: bool = False,
 ) -> str:
     """Return the endpoint for the assets of an entity.
 
@@ -111,10 +118,13 @@ def get_assets_endpoint(
         entity_type: The type of the entity.
         entity_id: The ID of the entity.
         asset_id: The ID of the asset.
+        admin: If true route is prefixed by admin, e.g. /admin/entity
 
     Returns:
         The endpoint for the assets of an entity.
     """
-    base_url = get_entities_endpoint(api_url=api_url, entity_type=entity_type, entity_id=entity_id)
+    base_url = get_entities_endpoint(
+        api_url=api_url, entity_type=entity_type, entity_id=entity_id, admin=admin
+    )
     asset_path = "assets" if asset_id is None else f"assets/{asset_id}"
     return f"{base_url}/{asset_path}"

--- a/src/entitysdk/types.py
+++ b/src/entitysdk/types.py
@@ -32,6 +32,9 @@ from entitysdk._server_schemas import ElectricalRecordingType as ElectricalRecor
 from entitysdk._server_schemas import EMCellMeshGenerationMethod as EMCellMeshGenerationMethod
 from entitysdk._server_schemas import EMCellMeshType as EMCellMeshType
 from entitysdk._server_schemas import EntityType as EntityType
+from entitysdk._server_schemas import MeasurableEntity as MeasurableEntity
+from entitysdk._server_schemas import MeasurementStatistic as MeasurementStatistic
+from entitysdk._server_schemas import MeasurementUnit as MeasurementUnit
 from entitysdk._server_schemas import ModifiedMorphologyMethodType as ModifiedMorphologyMethodType
 from entitysdk._server_schemas import PublicationType as PublicationType
 from entitysdk._server_schemas import Sex as Sex

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,10 +1,16 @@
 import uuid
+from typing import NamedTuple
 
 import pytest
 
 from entitysdk.client import Client
 from entitysdk.common import ProjectContext
 from tests.unit.util import PROJECT_ID, VIRTUAL_LAB_ID
+
+
+class Clients(NamedTuple):
+    with_context: Client
+    wout_context: Client
 
 
 @pytest.fixture(scope="session")
@@ -44,6 +50,19 @@ def request_headers_no_context(auth_token):
 @pytest.fixture
 def client(project_context, api_url, auth_token):
     return Client(api_url=api_url, project_context=project_context, token_manager=auth_token)
+
+
+@pytest.fixture
+def client_no_context(api_url, auth_token):
+    return Client(api_url=api_url, token_manager=auth_token)
+
+
+@pytest.fixture
+def clients(client, client_no_context):
+    return Clients(
+        with_context=client,
+        wout_context=client_no_context,
+    )
 
 
 @pytest.fixture

--- a/tests/unit/test_route.py
+++ b/tests/unit/test_route.py
@@ -19,6 +19,12 @@ def test_get_entities_endpoint(api_url):
     res = test_module.get_entities_endpoint(api_url=api_url, entity_type=Entity)
     assert res == f"{api_url}/entity"
 
+    res = test_module.get_entities_endpoint(api_url=api_url, entity_type=Entity, admin=False)
+    assert res == f"{api_url}/entity"
+
+    res = test_module.get_entities_endpoint(api_url=api_url, entity_type=Entity, admin=True)
+    assert res == f"{api_url}/admin/entity"
+
 
 def test_get_entities_endpoint__with_entity_id(api_url):
     res = test_module.get_entities_endpoint(api_url=api_url, entity_type=Entity, entity_id="1")


### PR DESCRIPTION
Support admin endpoints for:
* get_entity
* update_entity
* delete_entity
* delete_asset

Add get_entity_assets method that will return also deleted assets if ran by service admins with admin=True.


Example usage:

```python
client.get_entity(entity_id=entity_id, entity_type=entity_type, admin=True)
client.update_entity(entity_id=entity_id, entity_type=entity_type, admin=True)
client.delete_entity(entity_id=entity_id, entity_type=entity_type, admin=True)
client.delete_asset(entity_id=entity_id, entity_type=entity_type, asset_id=asset_id, admin=True)
client.get_entity_assets(entity_id=entity_id, entity_type=entity_type, admin=True)
```