### PR TITLE
Set custom http timeouts

### DIFF
--- a/src/entitysdk/config.py
+++ b/src/entitysdk/config.py
@@ -33,5 +33,34 @@ class Settings(BaseSettings):
         ),
     ] = "https://www.openbraininstitute.org/api/entitycore"
 
+    connect_timeout: Annotated[
+        float,
+        Field(
+            alias="ENTITYSDK_CONNECT_TIMEOUT",
+            description="Maximum time to wait until a connection is established, in seconds.",
+        ),
+    ] = 5
+    read_timeout: Annotated[
+        float,
+        Field(
+            alias="ENTITYSDK_READ_TIMEOUT",
+            description="Maximum time to wait for a chunk of data to be received, in seconds.",
+        ),
+    ] = 30
+    write_timeout: Annotated[
+        float,
+        Field(
+            alias="ENTITYSDK_WRITE_TIMEOUT",
+            description="Maximum time to wait for a chunk of data to be sent, in seconds.",
+        ),
+    ] = 30
+    pool_timeout: Annotated[
+        float,
+        Field(
+            alias="ENTITYSDK_POOL_TIMEOUT",
+            description="Maximum time to acquire a connection from the pool, in seconds.",
+        ),
+    ] = 5
+
 
 settings = Settings()

--- a/src/entitysdk/util.py
+++ b/src/entitysdk/util.py
@@ -46,6 +46,12 @@ def make_db_api_request(
             data=data,
             params=parameters,
             follow_redirects=True,
+            timeout=httpx.Timeout(
+                connect=settings.connect_timeout,
+                read=settings.read_timeout,
+                write=settings.write_timeout,
+                pool=settings.pool_timeout,
+            ),
         )
     except httpx.RequestError as e:
         raise EntitySDKError(f"Request error: {e}") from e


### PR DESCRIPTION
The default behavior of httpx is to raise a TimeoutException after 5 seconds of network inactivity, see https://www.python-httpx.org/advanced/timeouts/

With this PR the values can be configured differently, and the defaults for write and read are increased to 30 seconds.