### PR TITLE
Fix IonChannelRecording for nested schemas

### DIFF
--- a/src/entitysdk/models/ion_channel_recording.py
+++ b/src/entitysdk/models/ion_channel_recording.py
@@ -12,11 +12,11 @@ class IonChannelRecording(ElectricalRecording):
     """Ion channel recording model."""
 
     ion_channel: Annotated[
-        IonChannel,
+        IonChannel | None,
         Field(
             title="Ion channel",
         ),
-    ]
+    ] = None
     cell_line: Annotated[
         str,
         Field(


### PR DESCRIPTION
Cover both expanded and nested schemas as declared on the server side:

https://github.com/openbraininstitute/entitycore/blob/26b672ac90c37d7c2ea1cb9ee9f219086260b3cb/app/schemas/ion_channel_recording.py#L52