### PR TITLE
Add download memodel concurrency

### DIFF
--- a/src/entitysdk/downloaders/memodel.py
+++ b/src/entitysdk/downloaders/memodel.py
@@ -52,7 +52,7 @@ def download_memodel(
     if max_concurrent == 1:
         hoc_path = download_hoc(client, emodel, hoc_dir)
         if not hoc_path.exists():
-            raise StagingError(f"HOC does not exist: {hoc_path}")
+            raise StagingError(f"HOC file does not exist: {hoc_path}")
         morphology_path = _download_morph()
         mechanism_paths = [
             download_ion_channel_mechanism(client, ic, mechanisms_dir) for ic in ion_channels
@@ -69,7 +69,7 @@ def download_memodel(
             morphology_path = morphology_future.result()
             mechanism_paths = [f.result() for f in mechanism_futures]
         if not hoc_path.exists():
-            raise StagingError(f"HOC does not exist: {hoc_path}")
+            raise StagingError(f"HOC file does not exist: {hoc_path}")
 
     return DownloadedMEModel(
         hoc_path=hoc_path,

--- a/src/entitysdk/downloaders/memodel.py
+++ b/src/entitysdk/downloaders/memodel.py
@@ -1,5 +1,6 @@
 """Download functions for MEModel entities."""
 
+import concurrent.futures
 from pathlib import Path
 from typing import cast
 
@@ -14,13 +15,19 @@ from entitysdk.schemas.memodel import DownloadedMEModel
 from entitysdk.utils.filesystem import create_dir
 
 
-def download_memodel(client: Client, memodel: MEModel, output_dir=".") -> DownloadedMEModel:
+def download_memodel(
+    client: Client,
+    memodel: MEModel,
+    output_dir=".",
+    max_concurrent: int = 1,
+) -> DownloadedMEModel:
     """Download all assets needed to run an me-model: hoc, ion channel models, and morphology.
 
     Args:
         client (Client): EntitySDK client
         memodel (MEModel): MEModel entitysdk object
         output_dir (str): directory to save the downloaded files, defaults to current directory
+        max_concurrent (int): maximum number of concurrent downloads. Defaults to 1 (sequential).
     """
     # we have to get the emodel to get the ion channel models.
     emodel = cast(
@@ -28,29 +35,45 @@ def download_memodel(client: Client, memodel: MEModel, output_dir=".") -> Downlo
         client.get_entity(entity_id=memodel.emodel.id, entity_type=EModel),  # type: ignore
     )
 
-    hoc_path = download_hoc(client, emodel, Path(output_dir) / "hoc")
-    if not hoc_path.exists():
-        raise StagingError(f"HOC does not exist: {hoc_path}")
+    output_dir = Path(output_dir)
+    hoc_dir = output_dir / "hoc"
+    morphology_dir = output_dir / "morphology"
+    mechanisms_dir = create_dir(output_dir / "mechanisms")
+    ion_channels = list(emodel.ion_channel_models or [])
 
     # only take .asc format for now.
     # Will take specific format when morphology_format is integrated into MEModel
-    try:
-        morphology_path = download_morphology(
-            client, memodel.morphology, Path(output_dir) / "morphology", "asc"
-        )
-    except IteratorResultError:
-        morphology_path = download_morphology(
-            client, memodel.morphology, Path(output_dir) / "morphology", "swc"
-        )
-    mechanisms_dir = create_dir(Path(output_dir) / "mechanisms")
-    mechanism_files = []
-    for ic in emodel.ion_channel_models or []:
-        ion_channel_path = download_ion_channel_mechanism(client, ic, mechanisms_dir)
-        mechanism_files.append(ion_channel_path.name)
+    def _download_morph() -> Path:
+        try:
+            return download_morphology(client, memodel.morphology, morphology_dir, "asc")
+        except IteratorResultError:
+            return download_morphology(client, memodel.morphology, morphology_dir, "swc")
+
+    if max_concurrent == 1:
+        hoc_path = download_hoc(client, emodel, hoc_dir)
+        if not hoc_path.exists():
+            raise StagingError(f"HOC does not exist: {hoc_path}")
+        morphology_path = _download_morph()
+        mechanism_paths = [
+            download_ion_channel_mechanism(client, ic, mechanisms_dir) for ic in ion_channels
+        ]
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_concurrent) as executor:
+            hoc_future = executor.submit(download_hoc, client, emodel, hoc_dir)
+            morphology_future = executor.submit(_download_morph)
+            mechanism_futures = [
+                executor.submit(download_ion_channel_mechanism, client, ic, mechanisms_dir)
+                for ic in ion_channels
+            ]
+            hoc_path = hoc_future.result()
+            morphology_path = morphology_future.result()
+            mechanism_paths = [f.result() for f in mechanism_futures]
+        if not hoc_path.exists():
+            raise StagingError(f"HOC does not exist: {hoc_path}")
 
     return DownloadedMEModel(
         hoc_path=hoc_path,
         mechanisms_dir=mechanisms_dir,
-        mechanism_files=mechanism_files,
+        mechanism_files=[p.name for p in mechanism_paths],
         morphology_path=morphology_path,
     )

--- a/tests/unit/downloaders/test_memodel.py
+++ b/tests/unit/downloaders/test_memodel.py
@@ -236,7 +236,7 @@ def test_download_memodel_hoc_missing(tmp_path):
     memodel_mod.download_hoc = dummy_download_hoc
     with pytest.raises(StagingError) as excinfo:
         download_memodel(DummyClient(), DummyMEModel(), tmp_path)
-    assert "HOC does not exist" in str(excinfo.value)
+    assert "HOC file does not exist" in str(excinfo.value)
 
 
 @pytest.mark.parametrize("max_concurrent", [1, 4])

--- a/tests/unit/downloaders/test_memodel.py
+++ b/tests/unit/downloaders/test_memodel.py
@@ -223,7 +223,8 @@ class DummyClient:
         return DummyEModel()
 
 
-def test_download_memodel_hoc_missing(tmp_path):
+@pytest.mark.parametrize("max_concurrent", [1, 4])
+def test_download_memodel_hoc_missing(tmp_path, max_concurrent):
     class DummyMEModel:
         emodel = type("EModel", (), {"id": "dummy_id"})()
         morphology = "dummy_morphology"
@@ -231,11 +232,18 @@ def test_download_memodel_hoc_missing(tmp_path):
     def dummy_download_hoc(client, emodel, path):
         return tmp_path / "nonexistent_hoc_file.hoc"
 
+    def dummy_download_morphology(client, morphology, path, fmt):
+        morph_file = path / "dummy.asc"
+        morph_file.parent.mkdir(parents=True, exist_ok=True)
+        morph_file.write_text("asc")
+        return morph_file
+
     import entitysdk.downloaders.memodel as memodel_mod
 
     memodel_mod.download_hoc = dummy_download_hoc
+    memodel_mod.download_morphology = dummy_download_morphology
     with pytest.raises(StagingError) as excinfo:
-        download_memodel(DummyClient(), DummyMEModel(), tmp_path)
+        download_memodel(DummyClient(), DummyMEModel(), tmp_path, max_concurrent=max_concurrent)
     assert "HOC file does not exist" in str(excinfo.value)
 
 

--- a/tests/unit/downloaders/test_memodel.py
+++ b/tests/unit/downloaders/test_memodel.py
@@ -62,12 +62,14 @@ def _mock_emodel_asset_response(asset_id):
     }
 
 
+@pytest.mark.parametrize("max_concurrent", [1, 4])
 def test_download_memodel(
     tmp_path,
     client,
     httpx_mock,
     api_url,
     request_headers,
+    max_concurrent,
 ):
     """Test downloading all memodel-related files from an MEModel entity."""
     memodel_id = uuid.uuid4()
@@ -204,6 +206,7 @@ def test_download_memodel(
         client=client,
         memodel=memodel,
         output_dir=tmp_path,
+        max_concurrent=max_concurrent,
     )
     assert downloaded_memodel.hoc_path.is_file()
     assert downloaded_memodel.morphology_path.is_file()
@@ -236,7 +239,8 @@ def test_download_memodel_hoc_missing(tmp_path):
     assert "HOC does not exist" in str(excinfo.value)
 
 
-def test_download_memodel_morphology_asc_fallback_to_swc(tmp_path):
+@pytest.mark.parametrize("max_concurrent", [1, 4])
+def test_download_memodel_morphology_asc_fallback_to_swc(tmp_path, max_concurrent):
     class DummyMEModel:
         emodel = type("EModel", (), {"id": "dummy_id"})()
         morphology = "dummy_morphology"
@@ -259,5 +263,7 @@ def test_download_memodel_morphology_asc_fallback_to_swc(tmp_path):
 
     memodel_mod.download_hoc = dummy_download_hoc
     memodel_mod.download_morphology = dummy_download_morphology
-    result = download_memodel(DummyClient(), DummyMEModel(), tmp_path)
+    result = download_memodel(
+        DummyClient(), DummyMEModel(), tmp_path, max_concurrent=max_concurrent
+    )
     assert result.morphology_path.name == "dummy.swc"


### PR DESCRIPTION
## Summary

  Add optional concurrency to `download_memodel` so hoc file, morphology, and ion-channel mechanism downloads run in parallel. A similar pattern is [already used](https://github.com/openbraininstitute/entitysdk/blob/main/src/entitysdk/client.py#L590) when fetching a directory asset.

  ## Changes

  - `download_memodel` gains a `max_concurrent: int = 1` keyword argument, mirroring the pattern in `stage_circuit` / `client.fetch_directory`.
  - When `max_concurrent > 1`, HOC + morphology + N mechanism downloads are dispatched through a `ThreadPoolExecutor`. Default (`1`) preserves the existing sequential, fail-fast path byte-for-byte.
  - The morphology `.asc → .swc` fallback is extracted into a small local helper so it can run inside a single future.
  - `mechanism_files` ordering is preserved via named/indexed futures (no `wait().done` set).

  ## Notes

  - EModel fetch stays sequential and first — it's needed to enumerate ion channels.
  - In the concurrent path, the HOC existence check runs after all futures resolve (executor `__exit__` waits anyway), so a missing HOC fails slightly less eagerly than in the sequential path. Acceptable trade-off for simpler control flow.

  ## Test plan

  - [x] `test_download_memodel` parametrized with `max_concurrent=[1, 4]`
  - [x] `test_download_memodel_morphology_asc_fallback_to_swc` parametrized with `max_concurrent=[1, 4]` to cover the fallback running inside a worker thread
  - [x] `test_download_memodel_hoc_missing` unchanged (sequential `StagingError` path)
  - [x] `tox -e lint` clean