### PR TITLE
fix conductance setting in ICM staging

### DIFF
--- a/src/entitysdk/staging/ion_channel_model.py
+++ b/src/entitysdk/staging/ion_channel_model.py
@@ -236,7 +236,9 @@ def create_hoc_file(client, ion_channel_model_data, subdir_mech, subdir_hoc) -> 
         if "conductance" in icm_dict:
             conductance_name = find_conductance_or_max_permeability_name(icm_entity)
             if conductance_name is not None:
-                parameters[conductance_name] = icm_dict["conductance"]
+                parameters[f"{conductance_name}_{icm_entity.nmodl_suffix}"] = icm_dict[
+                    "conductance"
+                ]
             else:
                 L.warning(
                     "Could not find conductance parameter name for ion channel model "

--- a/tests/unit/staging/test_ion_channel_model.py
+++ b/tests/unit/staging/test_ion_channel_model.py
@@ -152,7 +152,7 @@ def test_create_hoc_file(client, tmp_path, httpx_mock, api_url, request_headers)
     assert (tmp_path / "mechanisms" / "Ca_LVAst.mod").exists()
     with open(tmp_path / "hocs" / "cell.hoc") as f:
         hoc_content = f.read()
-        assert "gCa_LVAstbar = 0.011" in hoc_content
+        assert "gCa_LVAstbar_Ca_LVAst = 0.011" in hoc_content
         assert "insert Ca_LVAst" in hoc_content
         assert "insert CaDynamics_DC0" in hoc_content
 


### PR DESCRIPTION
The conductance was not properly set when creating the hoc file. This is fixing it.

is needed to fix https://github.com/openbraininstitute/prod-build-ion-channel-model/issues/105