### PR TITLE
Make BrainAtlasRegion.volume nullable

### DIFF
--- a/src/entitysdk/models/brain_atlas_region.py
+++ b/src/entitysdk/models/brain_atlas_region.py
@@ -12,7 +12,7 @@ class BrainAtlasRegion(Entity):
     """BrainAtlasRegion model."""
 
     volume: Annotated[
-        float,
+        float | None,
         Field(
             examples=[0.25],
             description=(


### PR DESCRIPTION
Make BrainAtlasRegion.volume nullable to be aligned with the definition in entitycore:
- https://github.com/openbraininstitute/entitycore/blob/1a751227b8d3e3bc2ac27848725ba596150c5290/app/db/model.py#L1499
- https://github.com/openbraininstitute/entitycore/blob/1a751227b8d3e3bc2ac27848725ba596150c5290/app/schemas/brain_atlas_region.py#L20

For passing lint with mypy 2.0 it requires the changes already in https://github.com/openbraininstitute/entitysdk/pull/226