### PR TITLE
Add installed_packages and entitysdk_env to the migration RuntimeContext

### DIFF
--- a/src/entitysdk/migration/context.py
+++ b/src/entitysdk/migration/context.py
@@ -2,7 +2,9 @@
 
 import getpass
 import hashlib
+import importlib.metadata
 import logging
+import os
 import subprocess
 import sys
 from collections.abc import Generator
@@ -40,6 +42,8 @@ class RuntimeContext(BaseModel):
     git_dirty: list[str]
     script_hash: str
     uv_lock_hash: str
+    installed_packages: dict[str, str]
+    entitysdk_env: dict[str, str]
 
     @classmethod
     def collect(cls) -> "RuntimeContext":
@@ -55,6 +59,8 @@ class RuntimeContext(BaseModel):
             git_dirty=cls._git_dirty(),
             script_hash=cls._get_file_hash(git_root, script),
             uv_lock_hash=cls._get_file_hash(git_root, "uv.lock"),
+            installed_packages=cls._installed_packages(),
+            entitysdk_env=cls._entitysdk_env(),
         )
 
     @staticmethod
@@ -96,6 +102,19 @@ class RuntimeContext(BaseModel):
     def _get_file_hash(git_root: str, filename: str) -> str:
         content = (Path(git_root) / filename).read_bytes()
         return hashlib.sha256(content).hexdigest()
+
+    @staticmethod
+    def _installed_packages() -> dict[str, str]:
+        """Return installed packages as a name-version mapping."""
+        return {
+            dist.metadata["Name"]: dist.metadata["Version"]
+            for dist in importlib.metadata.distributions()
+        }
+
+    @staticmethod
+    def _entitysdk_env() -> dict[str, str]:
+        """Return environment variables starting with ENTITYSDK."""
+        return {key: value for key, value in os.environ.items() if key.startswith("ENTITYSDK")}
 
 
 class ExecutionManifest(BaseModel):

--- a/tests/unit/migration/test_context.py
+++ b/tests/unit/migration/test_context.py
@@ -32,6 +32,8 @@ def runtime_context():
         git_dirty=[],
         script_hash="aaa",
         uv_lock_hash="bbb",
+        installed_packages={"entitysdk": "0.1.0"},
+        entitysdk_env={},
     )
 
 
@@ -74,6 +76,20 @@ def test_runtime_context_collect(tmp_path, monkeypatch):
     assert ctx.git_dirty == []
     assert ctx.script_hash
     assert ctx.uv_lock_hash
+
+
+def test_runtime_context_installed_packages():
+    packages = test_module.RuntimeContext._installed_packages()
+    assert isinstance(packages, dict)
+    assert "pydantic" in packages
+
+
+def test_runtime_context_entitysdk_env(monkeypatch):
+    monkeypatch.setenv("ENTITYSDK_FOO", "bar")
+    monkeypatch.setenv("OTHER_VAR", "ignored")
+    env = test_module.RuntimeContext._entitysdk_env()
+    assert env["ENTITYSDK_FOO"] == "bar"
+    assert "OTHER_VAR" not in env
 
 
 def test_load_manifest(tmp_path, common_settings, runtime_context):


### PR DESCRIPTION
Add installed_packages and entitysdk_env to the migration RuntimeContext

- installed_packages is an explicit list of the installed packages, not depending on uv or uv.lock
- entitysdk_env should catch any env variable related to entitysdk as the ones defined in config.py (like ENTITYSDK_PAGE_SIZE)