### PR TITLE
Rename EntityKey to IdentifiableKey and change type to Identifiable class

### DIFF
--- a/src/entitysdk/migration/__init__.py
+++ b/src/entitysdk/migration/__init__.py
@@ -4,8 +4,8 @@ from entitysdk.migration.cli import run
 from entitysdk.migration.context import ExecutionManifest, init_client, load_manifest, script_dir
 from entitysdk.migration.settings import ApplySettings, CommonSettings, RevertSettings
 from entitysdk.migration.tracking import (
-    EntityKey,
     ExecutionSummary,
+    IdentifiableKey,
     OperationType,
     SnapshotLabel,
 )
@@ -13,7 +13,7 @@ from entitysdk.migration.tracking import (
 __all__ = [
     "ApplySettings",
     "CommonSettings",
-    "EntityKey",
+    "IdentifiableKey",
     "ExecutionManifest",
     "ExecutionSummary",
     "OperationType",

--- a/src/entitysdk/migration/tracking.py
+++ b/src/entitysdk/migration/tracking.py
@@ -13,8 +13,8 @@ from entitysdk.models.core import Identifiable
 L = logging.getLogger(__name__)
 
 
-class EntityKey(NamedTuple):
-    """Unique identifier for an entity."""
+class IdentifiableKey(NamedTuple):
+    """Unique identifier for an Identifiable."""
 
     type: type[Identifiable]
     id: UUID
@@ -24,8 +24,8 @@ class EntityKey(NamedTuple):
         return f"{self.type.__name__}::{self.id}"
 
     @classmethod
-    def from_string(cls, value: str) -> "EntityKey":
-        """Parse an EntityKey from its 'type::id' string representation."""
+    def from_string(cls, value: str) -> "IdentifiableKey":
+        """Parse an IdentifiableKey from its 'type::id' string representation."""
         type_str, _, id_str = value.partition("::")
         type_class = getattr(models, type_str, None)
         if not type_class:
@@ -64,13 +64,15 @@ class ExecutionSummary(BaseModel):
         Field(description="Before/after attribute values keyed by entity key."),
     ] = {}
 
-    def record_operation(self, entity_key: EntityKey, operation: OperationType) -> None:
+    def record_operation(self, identifiable_key: IdentifiableKey, operation: OperationType) -> None:
         """Record an operation performed on an entity."""
-        self.operations.setdefault(operation, []).append(str(entity_key))
+        self.operations.setdefault(operation, []).append(str(identifiable_key))
 
-    def record_snapshot(self, entity_key: EntityKey, label: SnapshotLabel, data: Any) -> None:
+    def record_snapshot(
+        self, identifiable_key: IdentifiableKey, label: SnapshotLabel, data: Any
+    ) -> None:
         """Record a before/after snapshot of an entity's data."""
-        self.snapshots.setdefault(str(entity_key), {})[label] = data
+        self.snapshots.setdefault(str(identifiable_key), {})[label] = data
 
     def log_summary(self) -> None:
         """Log a summary of all recorded operations."""

--- a/src/entitysdk/migration/tracking.py
+++ b/src/entitysdk/migration/tracking.py
@@ -7,24 +7,32 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
+from entitysdk import models
+from entitysdk.models.core import Identifiable
+
 L = logging.getLogger(__name__)
 
 
 class EntityKey(NamedTuple):
     """Unique identifier for an entity."""
 
-    type: str
+    type: type[Identifiable]
     id: UUID
 
     def __str__(self) -> str:
         """Return the string representation as 'type::id'."""
-        return f"{self.type}::{self.id}"
+        return f"{self.type.__name__}::{self.id}"
 
     @classmethod
     def from_string(cls, value: str) -> "EntityKey":
         """Parse an EntityKey from its 'type::id' string representation."""
-        type_, _, id_ = value.partition("::")
-        return cls(type=type_, id=UUID(id_))
+        type_str, _, id_str = value.partition("::")
+        type_class = getattr(models, type_str, None)
+        if not type_class:
+            raise ValueError(f"Unknown entity type: {type_str}")
+        if not issubclass(type_class, Identifiable):
+            raise ValueError(f"Invalid entity type: {type_str}")
+        return cls(type=type_class, id=UUID(id_str))
 
 
 class OperationType(StrEnum):

--- a/tests/unit/migration/test_context.py
+++ b/tests/unit/migration/test_context.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from entitysdk import models
 from entitysdk.common import ProjectContext
 from entitysdk.migration import context as test_module
 from entitysdk.migration.settings import CommonSettings
@@ -135,7 +136,7 @@ def test_migration_context_success(tmp_path, common_settings):
         common_settings, subcommand="apply", base=tmp_path
     ) as summary:
         summary.record_operation(
-            EntityKey(type="X", id=PROJECT_ID),
+            EntityKey(type=models.CellMorphology, id=PROJECT_ID),
             OperationType.created,
         )
 

--- a/tests/unit/migration/test_context.py
+++ b/tests/unit/migration/test_context.py
@@ -9,7 +9,7 @@ from entitysdk import models
 from entitysdk.common import ProjectContext
 from entitysdk.migration import context as test_module
 from entitysdk.migration.settings import CommonSettings
-from entitysdk.migration.tracking import EntityKey, ExecutionSummary, OperationType
+from entitysdk.migration.tracking import ExecutionSummary, IdentifiableKey, OperationType
 from entitysdk.types import DeploymentEnvironment
 from tests.unit.util import PROJECT_ID, VIRTUAL_LAB_ID
 
@@ -136,7 +136,7 @@ def test_migration_context_success(tmp_path, common_settings):
         common_settings, subcommand="apply", base=tmp_path
     ) as summary:
         summary.record_operation(
-            EntityKey(type=models.CellMorphology, id=PROJECT_ID),
+            IdentifiableKey(type=models.CellMorphology, id=PROJECT_ID),
             OperationType.created,
         )
 

--- a/tests/unit/migration/test_init.py
+++ b/tests/unit/migration/test_init.py
@@ -5,9 +5,9 @@ def test_public_api():
     expected = {
         "ApplySettings",
         "CommonSettings",
-        "EntityKey",
         "ExecutionManifest",
         "ExecutionSummary",
+        "IdentifiableKey",
         "OperationType",
         "RevertSettings",
         "SnapshotLabel",

--- a/tests/unit/migration/test_tracking.py
+++ b/tests/unit/migration/test_tracking.py
@@ -1,29 +1,45 @@
 import uuid
 
+import pytest
+
+from entitysdk import models
 from entitysdk.migration import tracking as test_module
 
 
 def test_entity_key_str():
-    key = test_module.EntityKey(type="Morphology", id=uuid.UUID(int=1))
-    assert str(key) == f"Morphology::{uuid.UUID(int=1)}"
+    key = test_module.EntityKey(type=models.CellMorphology, id=uuid.UUID(int=1))
+    assert str(key) == f"CellMorphology::{uuid.UUID(int=1)}"
 
 
 def test_entity_key_from_string():
     uid = uuid.uuid4()
-    key = test_module.EntityKey.from_string(f"Morphology::{uid}")
-    assert key.type == "Morphology"
+    key = test_module.EntityKey.from_string(f"CellMorphology::{uid}")
+    assert key.type == models.CellMorphology
     assert key.id == uid
 
 
+def test_entity_key_from_string_raises_when_unknown():
+    uid = uuid.uuid4()
+    with pytest.raises(ValueError, match="Unknown entity type"):
+        test_module.EntityKey.from_string(f"Unknown::{uid}")
+
+
+def test_entity_key_from_string_raises_when_not_identifiable(monkeypatch):
+    uid = uuid.uuid4()
+    monkeypatch.setattr(models, "NotIdentifiable", object, raising=False)
+    with pytest.raises(ValueError, match="Invalid entity type"):
+        test_module.EntityKey.from_string(f"NotIdentifiable::{uid}")
+
+
 def test_entity_key_roundtrip():
-    key = test_module.EntityKey(type="Circuit", id=uuid.uuid4())
+    key = test_module.EntityKey(type=models.Circuit, id=uuid.uuid4())
     assert test_module.EntityKey.from_string(str(key)) == key
 
 
 def test_entity_key_named_tuple_fields():
     uid = uuid.uuid4()
-    key = test_module.EntityKey(type="EModel", id=uid)
-    assert key.type == "EModel"
+    key = test_module.EntityKey(type=models.CellMorphology, id=uid)
+    assert key.type == models.CellMorphology
     assert key.id == uid
 
 
@@ -44,7 +60,7 @@ def test_execution_summary_default_operations():
 
 def test_execution_summary_record_operation():
     summary = test_module.ExecutionSummary()
-    key = test_module.EntityKey(type="Morphology", id=uuid.uuid4())
+    key = test_module.EntityKey(type=models.CellMorphology, id=uuid.uuid4())
     summary.record_operation(key, test_module.OperationType.created)
     assert str(key) in summary.operations[test_module.OperationType.created]
 
@@ -52,14 +68,14 @@ def test_execution_summary_record_operation():
 def test_execution_summary_record_operation_new_type():
     summary = test_module.ExecutionSummary()
     summary.operations.clear()
-    key = test_module.EntityKey(type="X", id=uuid.uuid4())
+    key = test_module.EntityKey(type=models.CellMorphology, id=uuid.uuid4())
     summary.record_operation(key, test_module.OperationType.updated)
     assert str(key) in summary.operations[test_module.OperationType.updated]
 
 
 def test_execution_summary_record_snapshot():
     summary = test_module.ExecutionSummary()
-    key = test_module.EntityKey(type="Morphology", id=uuid.uuid4())
+    key = test_module.EntityKey(type=models.CellMorphology, id=uuid.uuid4())
     summary.record_snapshot(key, test_module.SnapshotLabel.before, {"name": "old"})
     summary.record_snapshot(key, test_module.SnapshotLabel.after, {"name": "new"})
     entry = summary.snapshots[str(key)]
@@ -69,7 +85,7 @@ def test_execution_summary_record_snapshot():
 
 def test_execution_summary_log_summary(caplog):
     summary = test_module.ExecutionSummary()
-    key = test_module.EntityKey(type="X", id=uuid.uuid4())
+    key = test_module.EntityKey(type=models.CellMorphology, id=uuid.uuid4())
     summary.record_operation(key, test_module.OperationType.created)
     summary.record_operation(key, test_module.OperationType.skipped)
     with caplog.at_level("INFO"):

--- a/tests/unit/migration/test_tracking.py
+++ b/tests/unit/migration/test_tracking.py
@@ -6,39 +6,39 @@ from entitysdk import models
 from entitysdk.migration import tracking as test_module
 
 
-def test_entity_key_str():
-    key = test_module.EntityKey(type=models.CellMorphology, id=uuid.UUID(int=1))
+def test_identifiable_key_str():
+    key = test_module.IdentifiableKey(type=models.CellMorphology, id=uuid.UUID(int=1))
     assert str(key) == f"CellMorphology::{uuid.UUID(int=1)}"
 
 
-def test_entity_key_from_string():
+def test_identifiable_key_from_string():
     uid = uuid.uuid4()
-    key = test_module.EntityKey.from_string(f"CellMorphology::{uid}")
+    key = test_module.IdentifiableKey.from_string(f"CellMorphology::{uid}")
     assert key.type == models.CellMorphology
     assert key.id == uid
 
 
-def test_entity_key_from_string_raises_when_unknown():
+def test_identifiable_key_from_string_raises_when_unknown():
     uid = uuid.uuid4()
     with pytest.raises(ValueError, match="Unknown entity type"):
-        test_module.EntityKey.from_string(f"Unknown::{uid}")
+        test_module.IdentifiableKey.from_string(f"Unknown::{uid}")
 
 
-def test_entity_key_from_string_raises_when_not_identifiable(monkeypatch):
+def test_identifiable_key_from_string_raises_when_not_identifiable(monkeypatch):
     uid = uuid.uuid4()
     monkeypatch.setattr(models, "NotIdentifiable", object, raising=False)
     with pytest.raises(ValueError, match="Invalid entity type"):
-        test_module.EntityKey.from_string(f"NotIdentifiable::{uid}")
+        test_module.IdentifiableKey.from_string(f"NotIdentifiable::{uid}")
 
 
-def test_entity_key_roundtrip():
-    key = test_module.EntityKey(type=models.Circuit, id=uuid.uuid4())
-    assert test_module.EntityKey.from_string(str(key)) == key
+def test_identifiable_key_roundtrip():
+    key = test_module.IdentifiableKey(type=models.Circuit, id=uuid.uuid4())
+    assert test_module.IdentifiableKey.from_string(str(key)) == key
 
 
-def test_entity_key_named_tuple_fields():
+def test_identifiable_key_named_tuple_fields():
     uid = uuid.uuid4()
-    key = test_module.EntityKey(type=models.CellMorphology, id=uid)
+    key = test_module.IdentifiableKey(type=models.CellMorphology, id=uid)
     assert key.type == models.CellMorphology
     assert key.id == uid
 
@@ -60,7 +60,7 @@ def test_execution_summary_default_operations():
 
 def test_execution_summary_record_operation():
     summary = test_module.ExecutionSummary()
-    key = test_module.EntityKey(type=models.CellMorphology, id=uuid.uuid4())
+    key = test_module.IdentifiableKey(type=models.CellMorphology, id=uuid.uuid4())
     summary.record_operation(key, test_module.OperationType.created)
     assert str(key) in summary.operations[test_module.OperationType.created]
 
@@ -68,14 +68,14 @@ def test_execution_summary_record_operation():
 def test_execution_summary_record_operation_new_type():
     summary = test_module.ExecutionSummary()
     summary.operations.clear()
-    key = test_module.EntityKey(type=models.CellMorphology, id=uuid.uuid4())
+    key = test_module.IdentifiableKey(type=models.CellMorphology, id=uuid.uuid4())
     summary.record_operation(key, test_module.OperationType.updated)
     assert str(key) in summary.operations[test_module.OperationType.updated]
 
 
 def test_execution_summary_record_snapshot():
     summary = test_module.ExecutionSummary()
-    key = test_module.EntityKey(type=models.CellMorphology, id=uuid.uuid4())
+    key = test_module.IdentifiableKey(type=models.CellMorphology, id=uuid.uuid4())
     summary.record_snapshot(key, test_module.SnapshotLabel.before, {"name": "old"})
     summary.record_snapshot(key, test_module.SnapshotLabel.after, {"name": "new"})
     entry = summary.snapshots[str(key)]
@@ -85,7 +85,7 @@ def test_execution_summary_record_snapshot():
 
 def test_execution_summary_log_summary(caplog):
     summary = test_module.ExecutionSummary()
-    key = test_module.EntityKey(type=models.CellMorphology, id=uuid.uuid4())
+    key = test_module.IdentifiableKey(type=models.CellMorphology, id=uuid.uuid4())
     summary.record_operation(key, test_module.OperationType.created)
     summary.record_operation(key, test_module.OperationType.skipped)
     with caplog.at_level("INFO"):


### PR DESCRIPTION
This is a breaking change, but it would allow to set and get directly the type to the model class, instead of a string, that is usually more convenient in the migration scripts.
See for example the conversions needed in:
- https://github.com/openbraininstitute/migration-scripts/blob/2a12c705ef373703bb44ae16c8a38028123d91f7/entitycore/20260519_make_new_organizations/main.py#L52
- https://github.com/openbraininstitute/migration-scripts/blob/2a12c705ef373703bb44ae16c8a38028123d91f7/entitycore/20260519_make_new_organizations/main.py#L64-L65