### PR TITLE
Add mesh_lod_generation task type to TaskActivityType and TaskConfigType

### DIFF
--- a/src/entitysdk/_server_schemas.py
+++ b/src/entitysdk/_server_schemas.py
@@ -2241,7 +2241,8 @@ class TaskActivityType(StrEnum):
     extracellular_recording_weights_calculation__execution = (
         "extracellular_recording_weights_calculation__execution"
     )
-
+    mesh_lod_generation__config_generation = "mesh_lod_generation__config_generation"
+    mesh_lod_generation__execution = "mesh_lod_generation__execution"
 
 class TaskActivityUserUpdate(BaseModel):
     executor: ExecutorType | None = None
@@ -2276,7 +2277,8 @@ class TaskConfigType(StrEnum):
     extracellular_recording_weights_calculation__config = (
         "extracellular_recording_weights_calculation__config"
     )
-
+    mesh_lod_generation__campaign = "mesh_lod_generation__campaign"
+    mesh_lod_generation__config = "mesh_lod_generation__config"
 
 class TaskConfigUserUpdate(BaseModel):
     name: Annotated[str | None, Field(title="Name")] = None

--- a/src/entitysdk/_server_schemas.py
+++ b/src/entitysdk/_server_schemas.py
@@ -2437,6 +2437,7 @@ class AnalysisNotebookTemplateUpdate(BaseModel):
     description: Annotated[str | None, Field(title="Description")] = None
     specifications: AnalysisNotebookTemplateSpecifications | None = None
     scale: AnalysisScale | None = None
+    exercise_id: Annotated[UUID | None, Field(title="Exercise Id")] = None
 
 
 class AssetRead(BaseModel):
@@ -3594,6 +3595,7 @@ class NestedAnalysisNotebookTemplateRead(BaseModel):
     type: EntityType | None = None
     specifications: AnalysisNotebookTemplateSpecifications | None = None
     scale: AnalysisScale
+    exercise_id: Annotated[UUID | None, Field(title="Exercise Id")] = None
 
 
 class NestedContributionRead(BaseModel):
@@ -3956,6 +3958,7 @@ class AnalysisNotebookTemplateCreate(BaseModel):
     authorized_public: Annotated[bool | None, Field(title="Authorized Public")] = False
     specifications: AnalysisNotebookTemplateSpecifications | None = None
     scale: AnalysisScale
+    exercise_id: Annotated[UUID | None, Field(title="Exercise Id")] = None
 
 
 class AnalysisNotebookTemplateRead(BaseModel):
@@ -3973,6 +3976,7 @@ class AnalysisNotebookTemplateRead(BaseModel):
     type: EntityType | None = None
     specifications: AnalysisNotebookTemplateSpecifications | None = None
     scale: AnalysisScale
+    exercise_id: Annotated[UUID | None, Field(title="Exercise Id")] = None
 
 
 class AssetAndPresignedURLS(BaseModel):
@@ -5074,7 +5078,7 @@ class MeasurementAnnotationRead(BaseModel):
     measurement_kinds: Annotated[list[MeasurementKindRead], Field(title="Measurement Kinds")]
 
 
-class MeasurementAnnotationUserUpdate(BaseModel):
+class MeasurementAnnotationUpdate(BaseModel):
     entity_id: Annotated[UUID | None, Field(title="Entity Id")] = None
     entity_type: MeasurableEntity | None = None
     measurement_kinds: Annotated[

--- a/src/entitysdk/_server_schemas.py
+++ b/src/entitysdk/_server_schemas.py
@@ -2244,6 +2244,7 @@ class TaskActivityType(StrEnum):
     mesh_lod_generation__config_generation = "mesh_lod_generation__config_generation"
     mesh_lod_generation__execution = "mesh_lod_generation__execution"
 
+
 class TaskActivityUserUpdate(BaseModel):
     executor: ExecutorType | None = None
     execution_id: Annotated[UUID | None, Field(title="Execution Id")] = None
@@ -2279,6 +2280,7 @@ class TaskConfigType(StrEnum):
     )
     mesh_lod_generation__campaign = "mesh_lod_generation__campaign"
     mesh_lod_generation__config = "mesh_lod_generation__config"
+
 
 class TaskConfigUserUpdate(BaseModel):
     name: Annotated[str | None, Field(title="Name")] = None


### PR DESCRIPTION
Adds two new enum values to `_server_schemas.py` to support LOD mesh generation as a first-class asynchronous task.

### Changes

**`TaskActivityType`**
- `mesh_lod_generation__config_generation`
- `mesh_lod_generation__execution`

**`TaskConfigType`**
- `mesh_lod_generation__campaign`
- `mesh_lod_generation__config`

### Context

These are required by the obi-one backend, which is being updated to dispatch LOD generation as a launch-system task rather than running it synchronously inside the mesh registration endpoint.

The `mesh_lod_generation__config` label is used when uploading the task config JSON asset to a `TaskConfig` entity, and `mesh_lod_generation__execution` is used when creating and tracking the corresponding `TaskActivity`. The campaign and config-generation variants are included for consistency with all other task types in the schema.

### Related
- obi-one: mesh registration endpoint refactor (LOD generation as async task)