### PR TITLE
Increase request read timeout

### DIFF
--- a/src/entitysdk/config.py
+++ b/src/entitysdk/config.py
@@ -48,7 +48,7 @@ class Settings(BaseSettings):
         Field(
             description="Maximum time to wait for a chunk of data to be received, in seconds.",
         ),
-    ] = 30
+    ] = 300
     write_timeout: Annotated[
         float,
         Field(


### PR DESCRIPTION
Issue: When upload_directory was attempted with 300 files, the multipart completion request read timed out:

```python
File ~/Desktop/obi/repos/obi-one/.venv/lib/python3.12/site-packages/entitysdk/utils/http.py:58, in make_db_api_request(url, method, json, data, parameters, files, project_context, token_manager, http_client)     41     response = http_client.request(     42         method=method,     43         url=url,   (...)     55         ),     56     )     57 except httpx.RequestError as e:---> 58     raise EntitySDKError(f"Request error: {e}") from e     60 try:     61     response.raise_for_status()EntitySDKError: Request error: The read operation timed out
```
Solution: Inrease read timeout from 30s to 5mins for now until a better solution is implemented server-side.