### PR TITLE
Fix MEModel template use hoc template name in staging function

### DIFF
--- a/src/entitysdk/staging/ion_channel_model.py
+++ b/src/entitysdk/staging/ion_channel_model.py
@@ -306,6 +306,7 @@ def stage_sonata_from_config(
         mtype=mtype,
         threshold_current=threshold_current,
         holding_current=holding_current,
+        template_name="cell",
     )
 
     create_circuit_config(output_path=output_dir)

--- a/src/entitysdk/staging/memodel.py
+++ b/src/entitysdk/staging/memodel.py
@@ -66,9 +66,7 @@ def _extract_hoc_template_name(hoc_file: Path) -> str:
         if match:
             return match.group(1)
 
-    raise StagingError(
-        f"Could not find 'begintemplate' statement in HOC file: {hoc_file}"
-    )
+    raise StagingError(f"Could not find 'begintemplate' statement in HOC file: {hoc_file}")
 
 
 def stage_sonata_from_memodel(

--- a/src/entitysdk/staging/memodel.py
+++ b/src/entitysdk/staging/memodel.py
@@ -1,6 +1,7 @@
 """Staging functions for Single-Cell."""
 
 import logging
+import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -21,6 +22,53 @@ from entitysdk.utils.io import write_json
 L = logging.getLogger(__name__)
 
 DEFAULT_CIRCUIT_CONFIG_FILENAME = "circuit_config.json"
+
+
+def _extract_hoc_template_name(hoc_file: Path) -> str:
+    """Extract the template name from a HOC file by parsing the 'begintemplate' statement.
+
+    The SONATA model_template field requires the HOC template name (e.g. 'cADpyr_bin_4'),
+    not the filename. Neurodamus uses this name to look up the template in the NEURON namespace.
+
+    Skips lines that are inside comments (// single-line or /* */ block comments).
+
+    Args:
+        hoc_file: Path to the HOC file.
+
+    Returns:
+        The template name found in the HOC file.
+
+    Raises:
+        StagingError: If no 'begintemplate' statement is found in the HOC file.
+    """
+    content = Path(hoc_file).read_text()
+    in_block_comment = False
+
+    for line in content.splitlines():
+        stripped = line.strip()
+
+        # Track block comment state
+        if in_block_comment:
+            if "*/" in stripped:
+                in_block_comment = False
+            continue
+
+        if stripped.startswith("/*"):
+            if "*/" not in stripped:
+                in_block_comment = True
+            continue
+
+        # Skip single-line comments
+        if stripped.startswith("//"):
+            continue
+
+        match = re.match(r"begintemplate\s+(\w+)", stripped)
+        if match:
+            return match.group(1)
+
+    raise StagingError(
+        f"Could not find 'begintemplate' statement in HOC file: {hoc_file}"
+    )
 
 
 def stage_sonata_from_memodel(
@@ -106,6 +154,8 @@ def _generate_sonata_files_from_memodel(
             target = subdirs["mechanisms"] / file
             shutil.copy(src_path, target)
 
+    template_name = _extract_hoc_template_name(hoc_dst)
+
     create_nodes_file(
         hoc_file=str(hoc_dst),
         morph_file=str(morph_dst),
@@ -113,6 +163,7 @@ def _generate_sonata_files_from_memodel(
         mtype=mtype,
         threshold_current=threshold_current,
         holding_current=holding_current,
+        template_name=template_name,
     )
 
     create_circuit_config(output_path=output_path)
@@ -128,6 +179,7 @@ def create_nodes_file(
     mtype: str,
     threshold_current: float,
     holding_current: float,
+    template_name: str,
 ):
     """Create a SONATA nodes.h5 file for a single cell population.
 
@@ -138,6 +190,7 @@ def create_nodes_file(
         mtype (str): Cell mtype.
         threshold_current (float): Threshold current value.
         holding_current (float): Holding current value.
+        template_name (str): HOC template name (from begintemplate statement).
     """
     output_file = Path(output_file)  # ensure Path type
     output_file.parent.mkdir(parents=True, exist_ok=True)
@@ -154,7 +207,7 @@ def create_nodes_file(
 
         # Standard string properties
         group_0.create_dataset("model_template", (1,), dtype=h5py.string_dtype())[0] = (
-            f"hoc:{Path(hoc_file).stem}"
+            f"hoc:{template_name}"
         )
         group_0.create_dataset("model_type", (1,), dtype="int32")[0] = 0
         group_0.create_dataset("morph_class", (1,), dtype="int32")[0] = 0

--- a/src/entitysdk/staging/memodel.py
+++ b/src/entitysdk/staging/memodel.py
@@ -41,12 +41,11 @@ def _extract_hoc_template_name(hoc_file: Path) -> str:
     Raises:
         StagingError: If no 'begintemplate' statement is found in the HOC file.
     """
-    content = Path(hoc_file).read_text()
     content = hoc_file.read_text()
 
     # Remove block comments
     content = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
-    
+
     # Remove line comments
     content = re.sub(r"//.*$", "", content, flags=re.MULTILINE)
 

--- a/src/entitysdk/staging/memodel.py
+++ b/src/entitysdk/staging/memodel.py
@@ -42,29 +42,17 @@ def _extract_hoc_template_name(hoc_file: Path) -> str:
         StagingError: If no 'begintemplate' statement is found in the HOC file.
     """
     content = Path(hoc_file).read_text()
-    in_block_comment = False
+    content = hoc_file.read_text()
 
-    for line in content.splitlines():
-        stripped = line.strip()
+    # Remove block comments
+    content = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    
+    # Remove line comments
+    content = re.sub(r"//.*$", "", content, flags=re.MULTILINE)
 
-        # Track block comment state
-        if in_block_comment:
-            if "*/" in stripped:
-                in_block_comment = False
-            continue
-
-        if stripped.startswith("/*"):
-            if "*/" not in stripped:
-                in_block_comment = True
-            continue
-
-        # Skip single-line comments
-        if stripped.startswith("//"):
-            continue
-
-        match = re.match(r"begintemplate\s+(\w+)", stripped)
-        if match:
-            return match.group(1)
+    match = re.search(r"\bbegintemplate\s+(\w+)", content)
+    if match:
+        return match.group(1)
 
     raise StagingError(f"Could not find 'begintemplate' statement in HOC file: {hoc_file}")
 

--- a/tests/unit/downloaders/test_memodel.py
+++ b/tests/unit/downloaders/test_memodel.py
@@ -231,7 +231,7 @@ class DummyClient:
 
 
 @pytest.mark.parametrize("max_concurrent", [1, 4])
-def test_download_memodel_hoc_missing(tmp_path, max_concurrent):
+def test_download_memodel_hoc_missing(tmp_path, max_concurrent, monkeypatch):
     class DummyMEModel:
         emodel = type("EModel", (), {"id": "dummy_id"})()
         morphology = "dummy_morphology"
@@ -247,15 +247,15 @@ def test_download_memodel_hoc_missing(tmp_path, max_concurrent):
 
     import entitysdk.downloaders.memodel as memodel_mod
 
-    memodel_mod.download_hoc = dummy_download_hoc
-    memodel_mod.download_morphology = dummy_download_morphology
+    monkeypatch.setattr(memodel_mod, "download_hoc", dummy_download_hoc)
+    monkeypatch.setattr(memodel_mod, "download_morphology", dummy_download_morphology)
     with pytest.raises(StagingError) as excinfo:
         download_memodel(DummyClient(), DummyMEModel(), tmp_path, max_concurrent=max_concurrent)
     assert "HOC file does not exist" in str(excinfo.value)
 
 
 @pytest.mark.parametrize("max_concurrent", [1, 4])
-def test_download_memodel_morphology_asc_fallback_to_swc(tmp_path, max_concurrent):
+def test_download_memodel_morphology_asc_fallback_to_swc(tmp_path, max_concurrent, monkeypatch):
     class DummyMEModel:
         emodel = type("EModel", (), {"id": "dummy_id"})()
         morphology = "dummy_morphology"
@@ -276,8 +276,8 @@ def test_download_memodel_morphology_asc_fallback_to_swc(tmp_path, max_concurren
 
     import entitysdk.downloaders.memodel as memodel_mod
 
-    memodel_mod.download_hoc = dummy_download_hoc
-    memodel_mod.download_morphology = dummy_download_morphology
+    monkeypatch.setattr(memodel_mod, "download_hoc", dummy_download_hoc)
+    monkeypatch.setattr(memodel_mod, "download_morphology", dummy_download_morphology)
     result = download_memodel(
         DummyClient(), DummyMEModel(), tmp_path, max_concurrent=max_concurrent
     )

--- a/tests/unit/staging/conftest.py
+++ b/tests/unit/staging/conftest.py
@@ -325,6 +325,7 @@ def cell_morphology_protocol():
 @pytest.fixture
 def cell_morphology(brain_region, subject, mtype, cell_morphology_protocol):
     return CellMorphology(
+        id=uuid.uuid4(),
         name="cell-morphology",
         description="cell-morphology-description",
         cell_morphology_protocol=cell_morphology_protocol,
@@ -341,6 +342,7 @@ def cell_morphology(brain_region, subject, mtype, cell_morphology_protocol):
                 size=0,
                 is_directory=False,
                 storage_type=types.StorageType.aws_s3_internal,
+                status="created",
             ),
             Asset(
                 id=uuid.uuid4(),
@@ -351,6 +353,7 @@ def cell_morphology(brain_region, subject, mtype, cell_morphology_protocol):
                 size=0,
                 is_directory=False,
                 storage_type=types.StorageType.aws_s3_internal,
+                status="created",
             ),
             Asset(
                 id=uuid.uuid4(),
@@ -361,6 +364,7 @@ def cell_morphology(brain_region, subject, mtype, cell_morphology_protocol):
                 size=0,
                 is_directory=False,
                 storage_type=types.StorageType.aws_s3_internal,
+                status="created",
             ),
         ],
     )
@@ -376,10 +380,31 @@ def cell_morphology_httpx_mocks(
     entity_id = cell_morphology.id
     assets = cell_morphology.assets
 
+    # Asset metadata endpoints
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/{route}/{entity_id}/assets/{assets[0].id}",
+        json=assets[0].model_dump(mode="json"),
+        is_optional=True,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/{route}/{entity_id}/assets/{assets[1].id}",
+        json=assets[1].model_dump(mode="json"),
+        is_optional=True,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/{route}/{entity_id}/assets/{assets[2].id}",
+        json=assets[2].model_dump(mode="json"),
+        is_optional=True,
+    )
+    # Asset download endpoints
     httpx_mock.add_response(
         method="GET",
         url=_download_url(api_url, route, entity_id, assets[0].id),
         content=Path(DATA_DIR, "morph.swc").read_bytes(),
+        is_optional=True,
     )
     httpx_mock.add_response(
         method="GET",
@@ -390,6 +415,7 @@ def cell_morphology_httpx_mocks(
         method="GET",
         url=_download_url(api_url, route, entity_id, assets[2].id),
         content=Path(DATA_DIR, "morph.h5").read_bytes(),
+        is_optional=True,
     )
 
 
@@ -415,6 +441,7 @@ def emodel(brain_region, etype, species):
                 full_path="/emodel_optimization_output.json",
                 is_directory=False,
                 storage_type=types.StorageType.aws_s3_internal,
+                status="created",
             ),
             Asset(
                 id=uuid.uuid4(),
@@ -425,6 +452,7 @@ def emodel(brain_region, etype, species):
                 full_path="/neuron_hoc.hoc",
                 is_directory=False,
                 storage_type=types.StorageType.aws_s3_internal,
+                status="created",
             ),
         ],
     )
@@ -445,6 +473,20 @@ def emodel_httpx_mocks(
         url=f"{api_url}/emodel/{emodel.id}",
         json=emodel.model_dump(mode="json"),
     )
+    # Asset metadata endpoints (used by fetch_file when asset_id is a UUID)
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/{route}/{entity_id}/assets/{assets[0].id}",
+        json=assets[0].model_dump(mode="json"),
+        is_optional=True,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/{route}/{entity_id}/assets/{assets[1].id}",
+        json=assets[1].model_dump(mode="json"),
+        is_optional=True,
+    )
+    # Asset download endpoints
     httpx_mock.add_response(
         method="GET",
         url=_download_url(api_url, route, entity_id, assets[0].id),

--- a/tests/unit/staging/test_memodel.py
+++ b/tests/unit/staging/test_memodel.py
@@ -74,7 +74,7 @@ def test_generate_sonata_files_from_memodel_creates_structure(tmp_path):
     morph_path.parent.mkdir()
     mech_dir.mkdir()
 
-    (hoc_path).write_text("hoc content")
+    (hoc_path).write_text("begintemplate TestCell\nendtemplate TestCell\n")
     (morph_path).write_text("morph content")
     (mech_dir / "mech.mod").write_text("mod content")
 
@@ -105,6 +105,7 @@ def test_generate_sonata_files_from_memodel_creates_structure(tmp_path):
     # Validate content inside nodes.h5
     with h5py.File(output_path / "network" / "nodes.h5", "r") as f:
         group = f["nodes"]["All"]["0"]
+        assert group["model_template"][0].decode() == "hoc:TestCell"
         assert group["mtype"][0].decode() == "L5_TTPC1"
         assert group["dynamics_params"]["holding_current"][0] == pytest.approx(-0.1)
         assert group["dynamics_params"]["threshold_current"][0] == pytest.approx(0.2)
@@ -113,7 +114,7 @@ def test_generate_sonata_files_from_memodel_creates_structure(tmp_path):
 def test_create_json_configs(tmp_path):
     hoc_file = tmp_path / "cell.hoc"
     morph_file = tmp_path / "cell.asc"
-    hoc_file.write_text("hoc content")
+    hoc_file.write_text("begintemplate MyCell\nendtemplate MyCell\n")
     morph_file.write_text("morph content")
     network_dir = tmp_path / "network"
 
@@ -124,6 +125,7 @@ def test_create_json_configs(tmp_path):
         mtype="L5_TTPC1",
         threshold_current=0.2,
         holding_current=-0.1,
+        template_name="MyCell",
     )
 
     assert (network_dir / "nodes.h5").exists()
@@ -196,7 +198,7 @@ def test_mechanism_file_not_exists(tmp_path):
     (memodel_path / "hoc").mkdir()
     (memodel_path / "mechanisms").mkdir()
     (memodel_path / "morphology").mkdir()
-    (memodel_path / "hoc" / "cell.hoc").write_text("hoc content")
+    (memodel_path / "hoc" / "cell.hoc").write_text("begintemplate TestCell\nendtemplate TestCell\n")
     (memodel_path / "morphology" / "cell.asc").write_text("asc content")
     # Do not create the mechanism file
     downloaded_me_model = DownloadedMEModel(

--- a/tests/unit/staging/test_memodel.py
+++ b/tests/unit/staging/test_memodel.py
@@ -217,3 +217,24 @@ def test_mechanism_file_not_exists(tmp_path):
     )
     # The missing file should not be copied
     assert not (tmp_path / "mechanisms" / "missing.mod").exists()
+
+
+def test_extract_hoc_template_name_skips_comments(tmp_path):
+    hoc_file = tmp_path / "commented.hoc"
+    hoc_file.write_text(
+        "// begintemplate FakeComment\n"
+        "/*\n"
+        "  begintemplate FakeBlock\n"
+        "*/\n"
+        "/* begintemplate FakeSingleLine */\n"
+        "begintemplate RealTemplate\n"
+        "endtemplate RealTemplate\n"
+    )
+    assert memodel_mod._extract_hoc_template_name(hoc_file) == "RealTemplate"
+
+
+def test_extract_hoc_template_name_raises_when_missing(tmp_path):
+    hoc_file = tmp_path / "no_template.hoc"
+    hoc_file.write_text("// just a comment\nsome hoc code\n")
+    with pytest.raises(StagingError, match="Could not find 'begintemplate'"):
+        memodel_mod._extract_hoc_template_name(hoc_file)

--- a/tests/unit/staging/test_simulation_result.py
+++ b/tests/unit/staging/test_simulation_result.py
@@ -96,6 +96,7 @@ def test_stage_simulation_result__memodel(
     memodel,
     httpx_mock,
     emodel_httpx_mocks,
+    cell_morphology_httpx_mocks,
     simulation_httpx_mocks,
     simulation_result_httpx_mocks,
 ):


### PR DESCRIPTION
### **Issue**
- The model_template field in nodes.h5 was set to the HOC filename stem (e.g. `hoc:model` from model.hoc). Neurodamus strips the hoc: prefix and does getattr(Nd, emodel) to look up the cell template in the NEURON namespace. Since the actual template is defined as `begintemplate cADpyr_bin_4` inside the file, the lookup fails.

### **Fix**: 
- Parse the HOC file to extract the template name from the `begintemplate` statement. The parser skips // and /* ... */ comments to handle hand-edited HOC files.
- Before: model_template = `hoc:model` (filename) After: model_template = `hoc:cADpyr_bin_4` (template name from file content)
- Test fixes