### PR TITLE
Rename HOC file to match begintemplate name in memmodel staging function

### DIFF
--- a/src/entitysdk/staging/memodel.py
+++ b/src/entitysdk/staging/memodel.py
@@ -119,11 +119,14 @@ def _generate_sonata_files_from_memodel(
     for path in subdirs.values():
         create_dir(path)
 
-    # Copy hoc file
+    # Copy hoc file, renaming to match the template name inside it.
+    # Neurodamus loads HOC files as: <biophysical_neuron_models_dir>/<model_template>.hoc
+    # so the filename must match the begintemplate name.
     hoc_file = downloaded_memodel.hoc_path
     if not downloaded_memodel.hoc_path.exists():
         raise FileNotFoundError(f"No HOC file found {downloaded_memodel.hoc_path}")
-    hoc_dst = subdirs["hocs"] / hoc_file.name
+    template_name = _extract_hoc_template_name(hoc_file)
+    hoc_dst = subdirs["hocs"] / f"{template_name}.hoc"
     shutil.copy(hoc_file, hoc_dst)
 
     # Copy morphology file
@@ -138,8 +141,6 @@ def _generate_sonata_files_from_memodel(
         if Path(src_path).exists():
             target = subdirs["mechanisms"] / file
             shutil.copy(src_path, target)
-
-    template_name = _extract_hoc_template_name(hoc_dst)
 
     create_nodes_file(
         hoc_file=str(hoc_dst),

--- a/tests/unit/staging/test_memodel.py
+++ b/tests/unit/staging/test_memodel.py
@@ -95,7 +95,7 @@ def test_generate_sonata_files_from_memodel_creates_structure(tmp_path):
         holding_current=-0.1,
     )
 
-    assert (output_path / "hocs" / "cell.hoc").exists()
+    assert (output_path / "hocs" / "TestCell.hoc").exists()
     assert (output_path / "morphologies" / "cell.asc").exists()
     assert (output_path / "mechanisms" / "mech.mod").exists()
     assert (output_path / "network" / "nodes.h5").exists()
@@ -174,7 +174,7 @@ def test_missing_morphology_file_raises(tmp_path):
     (memodel_path / "hoc").mkdir()
     (memodel_path / "mechanisms").mkdir()
     (memodel_path / "morphology").mkdir()
-    (memodel_path / "hoc" / "cell.hoc").write_text("hoc content")
+    (memodel_path / "hoc" / "cell.hoc").write_text("begintemplate TestCell\nendtemplate TestCell\n")
 
     downloaded_me_model = DownloadedMEModel(
         hoc_path=memodel_path / "hoc" / "cell.hoc",


### PR DESCRIPTION
- Follow up of https://github.com/openbraininstitute/entitysdk/pull/254.
- Neurodamus loads HOC files as <biophysical_neuron_models_dir>/<model_template>.hoc, so the staged filename must match the template name defined inside the file. 
- See here SONATA [docs](https://sonata-extension.readthedocs.io/en/latest/sonata_tech.html#model-template) model_template and neuromdaus [code](https://github.com/openbraininstitute/neurodamus/blob/d2d66aaac5daa223bf682398d01424c5762d9c27/neurodamus/metype.py#L268) links for [details](https://github.com/openbraininstitute/neurodamus/blob/main/neurodamus/core/_neuron.py#L61). We can probably make it unabmiguous in the sonata extension documentation.
- Previously the file kept its original name (e.g. 'model.hoc') while model_template was set to 'hoc:cADpyr_bin_4', causing a file-not-found at load time.

> ...file kept its original name (e.g. 'model.hoc') while model_template was set to 'hoc:cADpyr_bin_4',

This works in BlueCelluLab. See [here](https://github.com/openbraininstitute/BlueCelluLab/blob/9df2c2deccbd6f66e72635ff5fb735a8c4c1fa08/bluecellulab/cell/template.py#L174) (for hoc loading) , [here](https://github.com/openbraininstitute/BlueCelluLab/blob/main/bluecellulab/circuit/circuit_access/sonata_circuit_access.py#L386) (for emodel path)and [here](https://github.com/openbraininstitute/BlueCelluLab/blob/main/bluecellulab/circuit_simulation.py#L1177) (to create a cell).
