### PR TITLE
Add compartment sets asset label

### DIFF
--- a/src/entitysdk/_server_schemas.py
+++ b/src/entitysdk/_server_schemas.py
@@ -132,6 +132,7 @@ class AssetLabel(StrEnum):
     simulation_generation_config = "simulation_generation_config"
     ion_channel_modeling_generation_config = "ion_channel_modeling_generation_config"
     custom_node_sets = "custom_node_sets"
+    compartment_sets = "compartment_sets"
     campaign_generation_config = "campaign_generation_config"
     campaign_summary = "campaign_summary"
     replay_spikes = "replay_spikes"

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -61,3 +61,7 @@ def test_ensure_id_is_set_rejects_asset_without_id():
     asset = _asset(asset_id=None)
     with pytest.raises(ValueError, match="Resource must have an id"):
         ensure_id_is_set(asset)
+
+
+def test_asset_label_includes_compartment_sets():
+    assert AssetLabel.compartment_sets.value == "compartment_sets"


### PR DESCRIPTION
## Summary
- Add `compartment_sets` to the generated `AssetLabel` enum
- Add a regression test confirming the SDK exposes the new label

## Depends On
- EntityCore [PR](https://github.com/openbraininstitute/entitycore/pull/674) adding and allowing the `compartment_sets` asset label for `Simulation`