### PR TITLE
Stage simulation compartment sets assets

### DIFF
--- a/src/entitysdk/downloaders/simulation.py
+++ b/src/entitysdk/downloaders/simulation.py
@@ -57,6 +57,34 @@ def download_node_sets_file(client: Client, *, model: Simulation, output_path: P
     return path
 
 
+def download_compartment_sets_file(
+    client: Client, *, model: Simulation, output_path: Path
+) -> Path | None:
+    """Download the compartment sets file from simulation's assets."""
+    ensure_has_id(model)
+
+    asset = client.select_assets(
+        model,
+        selection={"label": "compartment_sets"},
+    ).all()
+
+    if len(asset) == 0:
+        return None
+    if len(asset) > 1:
+        raise EntitySDKError(f"Too many compartment_sets_file for Simulation {model.id}")
+
+    path = client.download_file(
+        entity_id=model.id,
+        entity_type=Simulation,
+        asset_id=asset[0],
+        output_path=output_path,
+    )
+
+    L.info("Compartment sets file downloaded at %s", path)
+
+    return path
+
+
 def download_spike_replay_files(
     client: Client, *, model: Simulation, output_dir: Path
 ) -> list[Path]:

--- a/src/entitysdk/downloaders/simulation.py
+++ b/src/entitysdk/downloaders/simulation.py
@@ -57,32 +57,19 @@ def download_node_sets_file(client: Client, *, model: Simulation, output_path: P
     return path
 
 
-def download_compartment_sets_file(
-    client: Client, *, model: Simulation, output_path: Path
-) -> Path | None:
-    """Download the compartment sets file from simulation's assets."""
+def fetch_compartment_sets_file(client: Client, *, model: Simulation, output_path: Path) -> Path:
+    """Fetch the compartment sets file from simulation's assets."""
     ensure_has_id(model)
 
-    asset = client.select_assets(
-        model,
+    downloaded = client.fetch_assets(
+        entity_or_id=model,
         selection={"label": "compartment_sets"},
-    ).all()
-
-    if len(asset) == 0:
-        return None
-    if len(asset) > 1:
-        raise EntitySDKError(f"Too many compartment_sets_file for Simulation {model.id}")
-
-    path = client.download_file(
-        entity_id=model.id,
-        entity_type=Simulation,
-        asset_id=asset[0],
         output_path=output_path,
-    )
+    ).one()
 
-    L.info("Compartment sets file downloaded at %s", path)
+    L.info("Compartment sets file fetched at %s", downloaded.path)
 
-    return path
+    return downloaded.path
 
 
 def download_spike_replay_files(

--- a/src/entitysdk/downloaders/simulation.py
+++ b/src/entitysdk/downloaders/simulation.py
@@ -8,6 +8,7 @@ from entitysdk.client import Client
 from entitysdk.dependencies.entity import ensure_has_assets, ensure_has_id
 from entitysdk.exception import EntitySDKError
 from entitysdk.models import Simulation
+from entitysdk.types import AssetLabel, ContentType
 
 L = logging.getLogger(__name__)
 
@@ -59,11 +60,12 @@ def download_node_sets_file(client: Client, *, model: Simulation, output_path: P
 
 def fetch_compartment_sets_file(client: Client, *, model: Simulation, output_path: Path) -> Path:
     """Fetch the compartment sets file from simulation's assets."""
-    ensure_has_id(model)
-
     downloaded = client.fetch_assets(
         entity_or_id=model,
-        selection={"label": "compartment_sets"},
+        selection={
+            "label": AssetLabel.compartment_sets,
+            "content_type": ContentType.application_json,
+        },
         output_path=output_path,
     ).one()
 

--- a/src/entitysdk/staging/simulation.py
+++ b/src/entitysdk/staging/simulation.py
@@ -59,16 +59,13 @@ def stage_simulation(
         model=model,
         output_dir=output_dir,
     )
-    compartment_sets_path = simulation_config.get("compartment_sets_file")
-    compartment_sets_file = (
-        _stage_compartment_sets_file(
+    compartment_sets_file = None
+    if compartment_sets_path := simulation_config.get("compartment_sets_file"):
+        compartment_sets_file = _stage_compartment_sets_file(
             client=client,
             model=model,
             output_path=output_dir / Path(compartment_sets_path).name,
         )
-        if compartment_sets_path is not None
-        else None
-    )
     if circuit_config_path is None:
         L.info(
             "Circuit config path was not provided. Circuit is going to be staged from metadata. "

--- a/src/entitysdk/staging/simulation.py
+++ b/src/entitysdk/staging/simulation.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from entitysdk.client import Client
 from entitysdk.downloaders.simulation import (
+    download_compartment_sets_file,
     download_node_sets_file,
     download_simulation_config_content,
     download_spike_replay_files,
@@ -56,6 +57,12 @@ def stage_simulation(
     spike_paths: list[Path] = download_spike_replay_files(
         client,
         model=model,
+        output_dir=output_dir,
+    )
+    compartment_sets_file = _stage_compartment_sets_file(
+        client=client,
+        model=model,
+        simulation_config=simulation_config,
         output_dir=output_dir,
     )
     if circuit_config_path is None:
@@ -112,6 +119,7 @@ def stage_simulation(
         simulation_config=simulation_config,
         circuit_config_path=circuit_config_path,
         node_sets_path=node_sets_file,
+        compartment_sets_path=compartment_sets_file,
         spike_paths=spike_paths,
         output_dir=output_dir,
         override_results_dir=override_results_dir,
@@ -140,10 +148,36 @@ def _stage_single_cell_node_sets_file(
     return output_path
 
 
+def _stage_compartment_sets_file(
+    client: Client,
+    *,
+    model: Simulation,
+    simulation_config: dict,
+    output_dir: Path,
+) -> Path | None:
+    compartment_sets_file = simulation_config.get("compartment_sets_file")
+    if compartment_sets_file is None:
+        return None
+
+    output_path = output_dir / Path(compartment_sets_file).name
+    path = download_compartment_sets_file(
+        client,
+        model=model,
+        output_path=output_path,
+    )
+    if path is None:
+        raise StagingError(
+            "Simulation config references `compartment_sets_file`, but no "
+            "`compartment_sets` asset was found."
+        )
+    return path
+
+
 def _transform_simulation_config(
     simulation_config: dict,
     circuit_config_path: Path,
     node_sets_path: Path | None,
+    compartment_sets_path: Path | None,
     spike_paths: list[Path],
     output_dir: Path,
     override_results_dir: Path | None,
@@ -163,6 +197,9 @@ def _transform_simulation_config(
 
     if node_sets_path is not None:
         ret["node_sets_file"] = str(node_sets_path.relative_to(output_dir))
+
+    if compartment_sets_path is not None:
+        ret["compartment_sets_file"] = str(compartment_sets_path.relative_to(output_dir))
 
     return ret
 

--- a/src/entitysdk/staging/simulation.py
+++ b/src/entitysdk/staging/simulation.py
@@ -61,7 +61,7 @@ def stage_simulation(
     )
     compartment_sets_file = None
     if compartment_sets_path := simulation_config.get("compartment_sets_file"):
-        compartment_sets_file = _stage_compartment_sets_file(
+        compartment_sets_file = fetch_compartment_sets_file(
             client=client,
             model=model,
             output_path=output_dir / Path(compartment_sets_path).name,
@@ -147,19 +147,6 @@ def _stage_single_cell_node_sets_file(
         output_path,
     )
     return output_path
-
-
-def _stage_compartment_sets_file(
-    client: Client,
-    *,
-    model: Simulation,
-    output_path: Path,
-) -> Path:
-    return fetch_compartment_sets_file(
-        client,
-        model=model,
-        output_path=output_path,
-    )
 
 
 def _transform_simulation_config(

--- a/src/entitysdk/staging/simulation.py
+++ b/src/entitysdk/staging/simulation.py
@@ -6,10 +6,10 @@ from pathlib import Path
 
 from entitysdk.client import Client
 from entitysdk.downloaders.simulation import (
-    download_compartment_sets_file,
     download_node_sets_file,
     download_simulation_config_content,
     download_spike_replay_files,
+    fetch_compartment_sets_file,
 )
 from entitysdk.exception import StagingError
 from entitysdk.models import Circuit, MEModel, Simulation
@@ -59,11 +59,15 @@ def stage_simulation(
         model=model,
         output_dir=output_dir,
     )
-    compartment_sets_file = _stage_compartment_sets_file(
-        client=client,
-        model=model,
-        simulation_config=simulation_config,
-        output_dir=output_dir,
+    compartment_sets_path = simulation_config.get("compartment_sets_file")
+    compartment_sets_file = (
+        _stage_compartment_sets_file(
+            client=client,
+            model=model,
+            output_path=output_dir / Path(compartment_sets_path).name,
+        )
+        if compartment_sets_path is not None
+        else None
     )
     if circuit_config_path is None:
         L.info(
@@ -152,25 +156,13 @@ def _stage_compartment_sets_file(
     client: Client,
     *,
     model: Simulation,
-    simulation_config: dict,
-    output_dir: Path,
-) -> Path | None:
-    compartment_sets_file = simulation_config.get("compartment_sets_file")
-    if compartment_sets_file is None:
-        return None
-
-    output_path = output_dir / Path(compartment_sets_file).name
-    path = download_compartment_sets_file(
+    output_path: Path,
+) -> Path:
+    return fetch_compartment_sets_file(
         client,
         model=model,
         output_path=output_path,
     )
-    if path is None:
-        raise StagingError(
-            "Simulation config references `compartment_sets_file`, but no "
-            "`compartment_sets` asset was found."
-        )
-    return path
 
 
 def _transform_simulation_config(

--- a/tests/unit/downloaders/test_simulation.py
+++ b/tests/unit/downloaders/test_simulation.py
@@ -4,7 +4,7 @@ import uuid
 import pytest
 
 from entitysdk.downloaders import simulation as test_module
-from entitysdk.exception import EntitySDKError
+from entitysdk.exception import EntitySDKError, IteratorResultError
 from entitysdk.models import Simulation
 from entitysdk.types import AssetLabel, ContentType
 
@@ -96,7 +96,7 @@ def test_download_node_sets_file(
         assert expected == json.load(fd)
 
 
-def test_download_compartment_sets_file(
+def test_fetch_compartment_sets_file(
     client,
     tmp_path,
     httpx_mock,
@@ -105,21 +105,30 @@ def test_download_compartment_sets_file(
 ):
     simulation_id = uuid.uuid4()
 
-    # no assets
-    model = _mock_simulation(simulation_id, assets=[])
-    res = test_module.download_compartment_sets_file(client, model=model, output_path=tmp_path)
-    assert res is None
+    # no matching assets
+    asset_id = uuid.uuid4()
+    asset = _mock_asset_response(
+        asset_id, ContentType.application_json, AssetLabel.custom_node_sets
+    )
+    model = _mock_simulation(simulation_id, assets=[asset])
+    with pytest.raises(IteratorResultError, match="Iterable is empty."):
+        test_module.fetch_compartment_sets_file(
+            client,
+            model=model,
+            output_path=tmp_path / "compartment_sets.json",
+        )
 
-    # too many assets
     asset_id = uuid.uuid4()
     asset = _mock_asset_response(
         asset_id, ContentType.application_json, AssetLabel.compartment_sets
     )
-    model = _mock_simulation(simulation_id, assets=[asset, asset])
-    with pytest.raises(EntitySDKError, match="Too many compartment_sets_file for Simulation"):
-        test_module.download_compartment_sets_file(client, model=model, output_path=tmp_path)
-
     expected = {"foo": "bar"}
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/simulation/{simulation_id}/assets/{asset_id}",
+        match_headers=request_headers,
+        json=asset,
+    )
     httpx_mock.add_response(
         method="GET",
         url=f"{api_url}/simulation/{simulation_id}/assets/{asset_id}/download",
@@ -127,7 +136,11 @@ def test_download_compartment_sets_file(
         content=json.dumps(expected),
     )
     model = _mock_simulation(simulation_id, assets=[asset])
-    res = test_module.download_compartment_sets_file(client, model=model, output_path=tmp_path)
+    res = test_module.fetch_compartment_sets_file(
+        client,
+        model=model,
+        output_path=tmp_path / "compartment_sets.json",
+    )
     with res.open() as fd:
         assert expected == json.load(fd)
 

--- a/tests/unit/downloaders/test_simulation.py
+++ b/tests/unit/downloaders/test_simulation.py
@@ -96,6 +96,42 @@ def test_download_node_sets_file(
         assert expected == json.load(fd)
 
 
+def test_download_compartment_sets_file(
+    client,
+    tmp_path,
+    httpx_mock,
+    api_url,
+    request_headers,
+):
+    simulation_id = uuid.uuid4()
+
+    # no assets
+    model = _mock_simulation(simulation_id, assets=[])
+    res = test_module.download_compartment_sets_file(client, model=model, output_path=tmp_path)
+    assert res is None
+
+    # too many assets
+    asset_id = uuid.uuid4()
+    asset = _mock_asset_response(
+        asset_id, ContentType.application_json, AssetLabel.compartment_sets
+    )
+    model = _mock_simulation(simulation_id, assets=[asset, asset])
+    with pytest.raises(EntitySDKError, match="Too many compartment_sets_file for Simulation"):
+        test_module.download_compartment_sets_file(client, model=model, output_path=tmp_path)
+
+    expected = {"foo": "bar"}
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/simulation/{simulation_id}/assets/{asset_id}/download",
+        match_headers=request_headers,
+        content=json.dumps(expected),
+    )
+    model = _mock_simulation(simulation_id, assets=[asset])
+    res = test_module.download_compartment_sets_file(client, model=model, output_path=tmp_path)
+    with res.open() as fd:
+        assert expected == json.load(fd)
+
+
 def test_download_spike_replay_files(
     client,
     tmp_path,

--- a/tests/unit/staging/conftest.py
+++ b/tests/unit/staging/conftest.py
@@ -216,6 +216,7 @@ def simulation(circuit):
                 full_path="/compartment_sets.json",
                 size=0,
                 is_directory=False,
+                status=types.AssetStatus.created,
                 storage_type=types.StorageType.aws_s3_internal,
             ),
         ],
@@ -252,6 +253,12 @@ def simulation_httpx_mocks(
         method="GET",
         url=f"{api_url}/simulation/{simulation.id}/assets/{simulation.assets[3].id}/download",
         content=spike_replays,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/simulation/{simulation.id}/assets/{simulation.assets[4].id}",
+        json=simulation.assets[4].model_dump(mode="json"),
+        is_optional=True,
     )
     httpx_mock.add_response(
         method="GET",

--- a/tests/unit/staging/conftest.py
+++ b/tests/unit/staging/conftest.py
@@ -148,6 +148,11 @@ def node_sets():
 
 
 @pytest.fixture
+def compartment_sets():
+    return {"L1CompartmentSet": {"population": "All", "compartment_set": [[0, 1, 0.5]]}}
+
+
+@pytest.fixture
 def spike_replays():
     return Path(DATA_DIR, "spike_replays.h5").read_bytes()
 
@@ -203,13 +208,29 @@ def simulation(circuit):
                 is_directory=False,
                 storage_type=types.StorageType.aws_s3_internal,
             ),
+            Asset(
+                id=uuid.uuid4(),
+                content_type="application/json",
+                label="compartment_sets",
+                path="compartment_sets.json",
+                full_path="/compartment_sets.json",
+                size=0,
+                is_directory=False,
+                storage_type=types.StorageType.aws_s3_internal,
+            ),
         ],
     )
 
 
 @pytest.fixture
 def simulation_httpx_mocks(
-    httpx_mock, simulation, node_sets, api_url, simulation_config, spike_replays
+    httpx_mock,
+    simulation,
+    node_sets,
+    compartment_sets,
+    api_url,
+    simulation_config,
+    spike_replays,
 ):
     httpx_mock.add_response(
         method="GET",
@@ -231,6 +252,12 @@ def simulation_httpx_mocks(
         method="GET",
         url=f"{api_url}/simulation/{simulation.id}/assets/{simulation.assets[3].id}/download",
         content=spike_replays,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/simulation/{simulation.id}/assets/{simulation.assets[4].id}/download",
+        json=compartment_sets,
+        is_optional=True,
     )
 
 

--- a/tests/unit/staging/data/simulation_config.json
+++ b/tests/unit/staging/data/simulation_config.json
@@ -121,6 +121,7 @@
   },
   "node_set": "L1All",
   "node_sets_file": "$BASE_DIR/node_sets.json",
+  "compartment_sets_file": "$BASE_DIR/compartment_sets.json",
   "output": {
       "output_dir": "output",
       "spikes_file": "spikes.h5"

--- a/tests/unit/staging/test_simulation.py
+++ b/tests/unit/staging/test_simulation.py
@@ -31,6 +31,7 @@ def test_stage_simulation(
 
     expected_simulation_config_path = tmp_path / "simulation_config.json"
     expected_node_sets_path = tmp_path / "node_sets.json"
+    expected_compartment_sets_path = tmp_path / "compartment_sets.json"
     expected_spikes_1 = tmp_path / "PoissonInputStimulus_spikes_1.h5"
     expected_spikes_2 = tmp_path / "PoissonInputStimulus_spikes_2.h5"
     expected_circuit_config_path = tmp_path / "circuit" / "circuit_config.json"
@@ -39,6 +40,7 @@ def test_stage_simulation(
 
     assert expected_simulation_config_path.exists()
     assert expected_node_sets_path.exists()
+    assert expected_compartment_sets_path.exists()
     assert expected_spikes_1.exists()
     assert expected_spikes_2.exists()
     assert expected_circuit_config_path.exists()
@@ -48,6 +50,7 @@ def test_stage_simulation(
     res = load_json(expected_simulation_config_path)
     assert res["network"] == str(expected_circuit_config_path)
     assert res["node_sets_file"] == Path(expected_node_sets_path).name
+    assert res["compartment_sets_file"] == Path(expected_compartment_sets_path).name
 
     assert res["reports"] == simulation_config["reports"]
     assert res["conditions"] == simulation_config["conditions"]
@@ -78,17 +81,20 @@ def test_stage_simulation__external_circuit_config(
 
     expected_simulation_config_path = tmp_path / "simulation_config.json"
     expected_node_sets_path = tmp_path / "node_sets.json"
+    expected_compartment_sets_path = tmp_path / "compartment_sets.json"
     expected_spikes_1 = tmp_path / "PoissonInputStimulus_spikes_1.h5"
     expected_spikes_2 = tmp_path / "PoissonInputStimulus_spikes_2.h5"
 
     assert expected_simulation_config_path.exists()
     assert expected_node_sets_path.exists()
+    assert expected_compartment_sets_path.exists()
     assert expected_spikes_1.exists()
     assert expected_spikes_2.exists()
 
     res = load_json(expected_simulation_config_path)
     assert res["network"] == circuit_config_path
     assert res["node_sets_file"] == Path(expected_node_sets_path).name
+    assert res["compartment_sets_file"] == Path(expected_compartment_sets_path).name
 
     assert res["reports"] == simulation_config["reports"]
     assert res["conditions"] == simulation_config["conditions"]
@@ -135,6 +141,7 @@ def test__transform_simulation_config():
         simulation_config={},
         circuit_config_path=circuit_config_path,
         node_sets_path=None,
+        compartment_sets_path=None,
         spike_paths=[],
         output_dir=Path(),
         override_results_dir=None,
@@ -146,6 +153,7 @@ def test__transform_simulation_config():
             simulation_config={},
             circuit_config_path=circuit_config_path,
             node_sets_path=None,
+            compartment_sets_path=None,
             spike_paths=[
                 Path(),
             ],

--- a/tests/unit/staging/test_simulation.py
+++ b/tests/unit/staging/test_simulation.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -102,6 +103,32 @@ def test_stage_simulation__external_circuit_config(
     assert len(res["inputs"]) == len(simulation_config["inputs"])
     assert res["inputs"]["PoissonInputStimulus"]["spike_file"] == expected_spikes_1.name
     assert res["inputs"]["PoissonInputStimulus_2"]["spike_file"] == expected_spikes_2.name
+
+
+def test_stage_simulation__without_compartment_sets_file(
+    client,
+    tmp_path,
+    simulation,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        test_module,
+        "download_simulation_config_content",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(test_module, "download_spike_replay_files", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(test_module, "download_node_sets_file", lambda *_args, **_kwargs: None)
+    fetch_compartment_sets_file = Mock()
+    monkeypatch.setattr(test_module, "fetch_compartment_sets_file", fetch_compartment_sets_file)
+
+    test_module.stage_simulation(
+        client,
+        model=simulation,
+        output_dir=tmp_path,
+        circuit_config_path=Path("my-external-path"),
+    )
+
+    fetch_compartment_sets_file.assert_not_called()
 
 
 def test_transform_inputs__raises():


### PR DESCRIPTION
**Description**

Adds EntitySDK staging support for SONATA `compartment_sets_file`.

When a simulation config references `compartment_sets_file`, `stage_simulation(...)` now downloads the corresponding `compartment_sets` asset into the staged simulation directory and rewrites the config to point to the local staged file.

**Changes**

- Add `download_compartment_sets_file(...)` for Simulation assets.
- Stage `compartment_sets` assets when `simulation_config["compartment_sets_file"]` is present.
- Raise a `StagingError` if the config references compartment sets but no `compartment_sets` asset exists.
- Add downloader and staging unit tests.