### PR TITLE
Add admin parameter where missing

### DIFF
--- a/src/entitysdk/client.py
+++ b/src/entitysdk/client.py
@@ -137,7 +137,7 @@ class Client:
     def _optional_user_context(
         self,
         override_context: ProjectContext | None,
-        admin: bool = False,
+        admin: bool,
     ) -> ProjectContext | None:
         """Return an optional project context."""
         return None if admin else (override_context or self.project_context)
@@ -231,6 +231,7 @@ class Client:
         entity_type: type[Entity],
         derivation_type: DerivationType,
         project_context: ProjectContext | None = None,
+        admin: bool = False,
     ) -> IteratorResult[Entity]:
         """Get all derivations for an entity.
 
@@ -239,6 +240,7 @@ class Client:
             entity_type: Type of the entity.
             derivation_type: Derivation type to filter by.
             project_context: Optional project context.
+            admin: Whether to use the admin endpoints.
 
         Returns:
             An iterator over derivation entities, each with an assigned id.
@@ -248,9 +250,12 @@ class Client:
             entity_id=entity_id,
             entity_type=entity_type,
             derivation_type=derivation_type,
-            project_context=self._required_user_context(override_context=project_context),
+            project_context=self._optional_user_context(
+                override_context=project_context, admin=admin
+            ),
             token_manager=self._token_manager,
             http_client=self._http_client,
+            admin=admin,
         )
 
     @validate_call
@@ -272,7 +277,7 @@ class Client:
         return core.register_entity(
             api_url=self.api_url,
             entity=entity,
-            project_context=self._optional_user_context(project_context, admin=False),
+            project_context=self._required_user_context(project_context),
             http_client=self._http_client,
             token_manager=self._token_manager,
         )
@@ -451,7 +456,7 @@ class Client:
             metadata=file_metadata or {},
             label=asset_label,
         )
-        context = self._optional_user_context(override_context=project_context)
+        context = self._optional_user_context(override_context=project_context, admin=admin)
         return core.upload_asset_content(
             api_url=self.api_url,
             entity_id=entity_id,
@@ -476,6 +481,7 @@ class Client:
         label: AssetLabel,
         project_context: ProjectContext | None = None,
         transfer_config: MultipartDirectoryUploadTransferConfig | None = None,
+        admin: bool = False,
     ) -> Asset:
         """Attach a local directory to an entity.
 
@@ -488,11 +494,12 @@ class Client:
             label: Label for the asset.
             project_context: Optional project context.
             transfer_config: Optional multipart upload configuration.
+            admin: Whether to use the admin endpoints.
 
         Returns:
             The created directory Asset.
         """
-        context = self._optional_user_context(override_context=project_context)
+        context = self._optional_user_context(override_context=project_context, admin=admin)
 
         paths_dict = {Path(k): Path(v) for k, v in paths.items()}
 
@@ -508,6 +515,7 @@ class Client:
             http_client=self._http_client,
             token_manager=self._token_manager,
             transfer_config=transfer_config,
+            admin=admin,
         )
 
     @validate_call
@@ -518,6 +526,7 @@ class Client:
         entity_type: type[Entity],
         asset_id: ID,
         project_context: ProjectContext | None = None,
+        admin: bool = False,
     ) -> DetailedFileList:
         """List files in a directory asset.
 
@@ -526,11 +535,12 @@ class Client:
             entity_type: Type of the entity.
             asset_id: Directory asset id.
             project_context: Optional project context.
+            admin: Whether to use the admin endpoints.
 
         Returns:
             A `DetailedFileList` describing the directory contents.
         """
-        context = self._optional_user_context(override_context=project_context)
+        context = self._optional_user_context(override_context=project_context, admin=admin)
         return core.list_directory(
             api_url=self.api_url,
             entity_id=entity_id,
@@ -539,6 +549,7 @@ class Client:
             project_context=context,
             http_client=self._http_client,
             token_manager=self._token_manager,
+            admin=admin,
         )
 
     @validate_call
@@ -553,6 +564,7 @@ class Client:
         ignore_directory_name: bool = False,
         max_concurrent: int = 1,
         strategy: FetchFileStrategy = FetchFileStrategy.link_or_download,
+        admin: bool = False,
     ) -> list[Path]:
         """Fetch a directory asset to a local output directory.
 
@@ -566,6 +578,7 @@ class Client:
                 folder for the directory name.
             max_concurrent: Maximum number of concurrent downloads.
             strategy: Strategy controlling how files are materialized.
+            admin: Whether to use the admin endpoints.
 
         Returns:
             List of output file paths that were created.
@@ -578,7 +591,7 @@ class Client:
 
         output_path.mkdir(parents=True, exist_ok=True)
 
-        context = self._optional_user_context(override_context=project_context)
+        context = self._optional_user_context(override_context=project_context, admin=admin)
 
         if isinstance(asset_id, Asset):
             asset = asset_id
@@ -596,6 +609,7 @@ class Client:
                     project_context=context,
                     http_client=self._http_client,
                     token_manager=self._token_manager,
+                    admin=admin,
                 )
 
             output_path /= asset.path
@@ -605,6 +619,7 @@ class Client:
             entity_type=entity_type,
             asset_id=asset_id,
             project_context=project_context,
+            admin=admin,
         )
 
         if max_concurrent == 1:
@@ -617,6 +632,7 @@ class Client:
                     asset_path=path,
                     project_context=context,
                     strategy=strategy,
+                    admin=admin,
                 )
                 for path in contents.files
             ]
@@ -632,6 +648,7 @@ class Client:
                         asset_path=path,
                         project_context=context,
                         strategy=strategy,
+                        admin=admin,
                     )
                     for path in contents.files
                 ]
@@ -651,6 +668,7 @@ class Client:
         project_context: ProjectContext | None = None,
         ignore_directory_name: bool = False,
         max_concurrent: int = 1,
+        admin: bool = False,
     ) -> list[Path]:
         """Download a directory asset to local disk.
 
@@ -663,6 +681,7 @@ class Client:
             ignore_directory_name: If `True`, do not create an extra nested
                 folder for the directory name.
             max_concurrent: Maximum number of concurrent downloads.
+            admin: Whether to use the admin endpoints.
 
         Returns:
             List of output file paths that were created.
@@ -676,6 +695,7 @@ class Client:
             ignore_directory_name=ignore_directory_name,
             max_concurrent=max_concurrent,
             strategy=FetchFileStrategy.download_only,
+            admin=admin,
         )
 
     @validate_call

--- a/src/entitysdk/core.py
+++ b/src/entitysdk/core.py
@@ -158,16 +158,18 @@ def get_entity_derivations(
     api_url: str,
     entity_id: ID,
     entity_type: type[Entity],
-    project_context: ProjectContext,
+    project_context: ProjectContext | None,
     derivation_type: DerivationType,
     token_manager: TokenManager,
     http_client: httpx.Client,
+    admin: bool,
 ) -> IteratorResult[Entity]:
     """Get derivations for entity."""
     url = get_entity_derivations_endpoint(
         api_url=api_url,
         entity_type=entity_type,
         entity_id=entity_id,
+        admin=admin,
     )
 
     params = {"derivation_type": DerivationType(derivation_type)}
@@ -356,6 +358,7 @@ def upload_asset_file(
             token_manager=token_manager,
             transfer_config=transfer_config,
             http_client=http_client,
+            admin=admin,
         )
     with open(asset_path, "rb") as file_content:
         return upload_asset_content(
@@ -423,6 +426,7 @@ def upload_asset_directory(
     token_manager: TokenManager,
     http_client: httpx.Client,
     transfer_config: MultipartDirectoryUploadTransferConfig | None = None,
+    admin: bool,
 ) -> Asset:
     """Upload a group of files to a directory using multipart-upload."""
     transfer_config = transfer_config or MultipartDirectoryUploadTransferConfig()
@@ -456,6 +460,7 @@ def upload_asset_directory(
         transfer_config=transfer_config,
         upload_request=upload_request,
         paths=paths,
+        admin=admin,
     )
 
 
@@ -468,6 +473,7 @@ def list_directory(
     token_manager: TokenManager,
     project_context: ProjectContext | None = None,
     http_client: httpx.Client,
+    admin: bool,
 ) -> DetailedFileList:
     """List all files within an asset directory."""
     url = (
@@ -476,6 +482,7 @@ def list_directory(
             entity_type=entity_type,
             entity_id=entity_id,
             asset_id=asset_id,
+            admin=admin,
         )
         + "/list"
     )

--- a/src/entitysdk/multipart_upload.py
+++ b/src/entitysdk/multipart_upload.py
@@ -103,6 +103,7 @@ def multipart_upload_asset_file(
     token_manager: TokenManager,
     http_client: httpx.Client,
     transfer_config: MultipartUploadTransferConfig,
+    admin: bool,
 ) -> Asset:
     """Upload a local asset file in multiple parts to the storage service using presigned URLs.
 
@@ -120,6 +121,7 @@ def multipart_upload_asset_file(
         token_manager: Object providing authentication tokens for API requests.
         http_client: HTTP client to use for uploads.
         transfer_config: Configuration for multipart upload.
+        admin: Whether to use the admin endpoints.
 
     Returns:
         Asset: The file asset object as returned by the backend after completion.
@@ -134,6 +136,7 @@ def multipart_upload_asset_file(
         token_manager=token_manager,
         http_client=http_client,
         preferred_part_count=transfer_config.preferred_part_count,
+        admin=admin,
     )
     _upload_parts(
         parts=parts,
@@ -148,6 +151,7 @@ def multipart_upload_asset_file(
         project_context=project_context,
         token_manager=token_manager,
         http_client=http_client,
+        admin=admin,
     )
 
 
@@ -162,6 +166,7 @@ def _initiate_upload(
     preferred_part_count: int,
     token_manager: TokenManager,
     http_client: httpx.Client,
+    admin: bool,
 ) -> tuple[ID, list[PartUpload]]:
     """Initiate a multipart upload with the backend and prepare part metadata.
 
@@ -183,6 +188,7 @@ def _initiate_upload(
         api_url=api_url,
         entity_id=entity_id,
         entity_type=entity_type,
+        admin=admin,
     )
     filesize = get_filesize(asset_path)
     data = make_db_api_request(
@@ -359,6 +365,7 @@ def _complete_upload(
     project_context: ProjectContext | None,
     token_manager: TokenManager,
     http_client: httpx.Client,
+    admin: bool,
 ) -> Asset:
     """Finalize a multipart upload with the backend and return the created asset.
 
@@ -377,6 +384,7 @@ def _complete_upload(
         entity_id=entity_id,
         entity_type=entity_type,
         asset_id=asset_id,
+        admin=admin,
     )
     data = make_db_api_request(
         url=url,
@@ -399,6 +407,7 @@ def multipart_upload_asset_directory(
     transfer_config: MultipartDirectoryUploadTransferConfig,
     upload_request: MultipartDirectoryUploadRequest,
     paths: dict[Path, Path],
+    admin: bool,
 ) -> Asset:
     """Upload files in a local directory in multiple parts using presigned URLs.
 
@@ -419,6 +428,7 @@ def multipart_upload_asset_directory(
         transfer_config: Configuration for multipart upload.
         upload_request: Request parameters for the upload.
         paths: Mapping of relative paths to local file paths.
+        admin: Whether to use the admin endpoints.
 
     Returns:
         Asset: The directory asset object as returned by the backend after completion.
@@ -432,6 +442,7 @@ def multipart_upload_asset_directory(
         http_client=http_client,
         upload_request=upload_request,
         paths=paths,
+        admin=admin,
     )
     _upload_parts(
         parts=parts,
@@ -446,6 +457,7 @@ def multipart_upload_asset_directory(
         project_context=project_context,
         token_manager=token_manager,
         http_client=http_client,
+        admin=admin,
     )
 
 
@@ -459,6 +471,7 @@ def _initiate_directory_upload(
     http_client: httpx.Client,
     upload_request: MultipartDirectoryUploadRequest,
     paths: dict[Path, Path],
+    admin: bool,
 ) -> tuple[ID, list[PartUpload]]:
     """Initiate a multipart directory upload with the backend and prepare part metadata.
 
@@ -468,6 +481,7 @@ def _initiate_directory_upload(
         api_url=api_url,
         entity_id=entity_id,
         entity_type=entity_type,
+        admin=admin,
     )
     data = make_db_api_request(
         url=url,
@@ -514,6 +528,7 @@ def _complete_upload_directory(
     project_context: ProjectContext | None,
     token_manager: TokenManager,
     http_client: httpx.Client,
+    admin: bool,
 ) -> Asset:
     """Finalize a multipart directory upload with the backend and return the created asset.
 
@@ -524,6 +539,7 @@ def _complete_upload_directory(
         entity_id=entity_id,
         entity_type=entity_type,
         asset_id=asset_id,
+        admin=admin,
     )
     data = make_db_api_request(
         url=url,

--- a/src/entitysdk/route.py
+++ b/src/entitysdk/route.py
@@ -125,9 +125,14 @@ def get_entity_derivations_endpoint(
     api_url: str,
     entity_type: type[Entity],
     entity_id: ID,
+    admin: bool,
 ):
     """Get endpoint for entity derivations."""
     route_name = get_route_name(entity_type)
+
+    if admin:
+        route_name = f"admin/{route_name}"
+
     return f"{api_url}/{route_name}/{entity_id}/derived-from"
 
 
@@ -163,13 +168,14 @@ def multipart_upload_initiate_endpoint(
     api_url: str,
     entity_id: str | ID,
     entity_type: type[Entity],
+    admin: bool,
 ):
     """Return multipart upload initiate upload."""
     base_url = get_entities_endpoint(
         api_url=api_url,
         entity_type=entity_type,
         entity_id=entity_id,
-        admin=False,
+        admin=admin,
     )
     return f"{base_url}/assets/multipart-upload/initiate"
 
@@ -180,13 +186,14 @@ def multipart_upload_complete_endpoint(
     entity_id: str | ID,
     entity_type: type[Entity],
     asset_id: str | ID,
+    admin: bool,
 ):
     """Return multipart upload complete endpoint."""
     base_url = get_entities_endpoint(
         api_url=api_url,
         entity_type=entity_type,
         entity_id=entity_id,
-        admin=False,
+        admin=admin,
     )
     return f"{base_url}/assets/{asset_id}/multipart-upload/complete"
 
@@ -196,13 +203,14 @@ def multipart_upload_initiate_endpoint_directory(
     api_url: str,
     entity_id: str | ID,
     entity_type: type[Entity],
+    admin: bool,
 ):
     """Return multipart upload initiate upload for directories."""
     base_url = get_entities_endpoint(
         api_url=api_url,
         entity_type=entity_type,
         entity_id=entity_id,
-        admin=False,
+        admin=admin,
     )
     return f"{base_url}/assets/directory/multipart-upload/initiate"
 
@@ -213,12 +221,13 @@ def multipart_upload_complete_endpoint_directory(
     entity_id: str | ID,
     entity_type: type[Entity],
     asset_id: str | ID,
+    admin: bool,
 ):
     """Return multipart upload complete endpoint for directories."""
     base_url = get_entities_endpoint(
         api_url=api_url,
         entity_type=entity_type,
         entity_id=entity_id,
-        admin=False,
+        admin=admin,
     )
     return f"{base_url}/assets/{asset_id}/directory/multipart-upload/complete"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1447,3 +1447,106 @@ def test_client_delete_entity(mock_route, clients, httpx_mock, api_url, request_
     )
 
     clients.wout_context.delete_entity(entity_id=entity_id, entity_type=Entity, admin=True)
+
+
+@patch("entitysdk.route.get_route_name")
+def test_client_admin_get_entity_derivations(
+    mock_route, client, httpx_mock, api_url, request_headers_no_context
+):
+    mock_route.return_value = "circuit"
+    entity_id = uuid.uuid4()
+    used_id = uuid.uuid4()
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/admin/circuit/{entity_id}/derived-from?derivation_type=circuit_extraction",
+        match_headers=request_headers_no_context,
+        json={"data": [{"type": "circuit", "id": str(used_id)}]},
+    )
+
+    res = client.get_entity_derivations(
+        entity_id=entity_id,
+        entity_type=Circuit,
+        derivation_type=DerivationType.circuit_extraction,
+        admin=True,
+    ).all()
+    assert len(res) == 1
+    assert res[0].id == used_id
+
+
+@patch("entitysdk.route.get_route_name")
+def test_client_admin_upload_content(
+    mock_route, client, httpx_mock, api_url, request_headers_no_context
+):
+    mock_route.return_value = "entity"
+    entity_id = uuid.uuid4()
+    asset_id = uuid.uuid4()
+
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{api_url}/admin/entity/{entity_id}/assets",
+        match_headers=request_headers_no_context,
+        json=_mock_asset_response(asset_id=asset_id),
+    )
+
+    res = client.upload_content(
+        entity_id=entity_id,
+        entity_type=Entity,
+        file_name="foo.swc",
+        file_content=b"foo",
+        file_content_type=ContentType.application_swc,
+        asset_label=AssetLabel.morphology,
+        admin=True,
+    )
+    assert res.id == asset_id
+
+
+@patch("entitysdk.route.get_route_name")
+def test_client_admin_list_directory(
+    mock_route, client, httpx_mock, api_url, request_headers_no_context
+):
+    mock_route.return_value = "entity"
+    entity_id = uuid.uuid4()
+    asset_id = uuid.uuid4()
+    date = "2025-01-01T00:00:00Z"
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{api_url}/admin/entity/{entity_id}/assets/{asset_id}/list",
+        match_headers=request_headers_no_context,
+        json={"files": {"foo.txt": {"name": "foo.txt", "size": 1, "last_modified": date}}},
+    )
+
+    res = client.list_directory(
+        entity_id=entity_id,
+        entity_type=Entity,
+        asset_id=asset_id,
+        admin=True,
+    )
+    assert isinstance(res, DetailedFileList)
+    assert len(res.files) == 1
+
+
+@patch("entitysdk.route.get_route_name")
+def test_client_admin_upload_directory(
+    mock_route, client, httpx_mock, api_url, request_headers_no_context, tmp_path
+):
+    mock_route.return_value = "entity"
+    entity_id = uuid.uuid4()
+
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("hello")
+
+    with patch("entitysdk.core.upload_asset_directory") as mock_upload:
+        mock_upload.return_value = _mock_asset_response(asset_id=uuid.uuid4())
+        client.upload_directory(
+            entity_id=entity_id,
+            entity_type=Entity,
+            name="my-dir",
+            paths={Path("file.txt"): file_path},
+            label=AssetLabel.morphology,
+            admin=True,
+        )
+        _, kwargs = mock_upload.call_args
+        assert kwargs["admin"] is True
+        assert kwargs["project_context"] is None

--- a/tests/unit/test_multipart_upload.py
+++ b/tests/unit/test_multipart_upload.py
@@ -170,6 +170,7 @@ def test_multipart_upload_asset_file(
             token_manager=token_manager,
             transfer_config=transfer_config_sequential,
             http_client=httpx.Client(),
+            admin=False,
         )
 
         mock_initiate.assert_called_once()
@@ -195,6 +196,7 @@ def test_multipart_upload_asset_file(
             token_manager=token_manager,
             transfer_config=transfer_config_sequential,
             http_client=http_client,
+            admin=False,
         )
 
         mock_initiate.assert_called_once()
@@ -261,6 +263,7 @@ def test_initiate_upload(
         preferred_part_count=10,
         token_manager=token_from_value_manager,
         http_client=httpx.Client(),
+        admin=False,
     )
 
     assert res_asset_id == ASSET_ID
@@ -332,6 +335,7 @@ def test_complete_upload(httpx_mock, project_context, asset_payload, token_from_
         project_context=project_context,
         token_manager=token_from_value_manager,
         http_client=http_client,
+        admin=False,
     )
     assert res.status == "created"
 
@@ -443,6 +447,7 @@ def test_initiate_directory_upload_file_count_mismatch(httpx_mock, project_conte
             http_client=httpx.Client(),
             upload_request=upload_request,
             paths=paths,
+            admin=False,
         )
 
 

--- a/tests/unit/test_route.py
+++ b/tests/unit/test_route.py
@@ -43,6 +43,11 @@ def test_get_assets_endpoint(api_url):
 
 def test_get_entity_derivations_endpoint(api_url):
     res = test_module.get_entity_derivations_endpoint(
-        api_url=api_url, entity_type=Entity, entity_id="1"
+        api_url=api_url, entity_type=Entity, entity_id="1", admin=False
     )
     assert res == f"{api_url}/entity/1/derived-from"
+
+    res = test_module.get_entity_derivations_endpoint(
+        api_url=api_url, entity_type=Entity, entity_id="1", admin=True
+    )
+    assert res == f"{api_url}/admin/entity/1/derived-from"


### PR DESCRIPTION
Propagate the `admin` flag across all client methods and their underlying core/multipart/route helpers that were missing it.

It needs the changes in https://github.com/openbraininstitute/entitycore/pull/681

### Changes

- **`client.py`**: added `admin` parameter to `get_entity_derivations`,
  `upload_content`, `upload_directory`, `list_directory`, `fetch_directory`,
  and `download_directory`; fixed `get_entity_derivations` to use `_optional_user_context`; fixed `register_entity` to use `_required_user_context`
- **`core.py`**: updated `get_entity_derivations` signature to accept
  `admin` and pass it to the route helper; relaxed `project_context` to
  `ProjectContext | None`
- **`multipart_upload.py`**: added `admin` to
  `multipart_upload_asset_file`, `_initiate_upload`, `_complete_upload`,
  `multipart_upload_asset_directory`, `_initiate_directory_upload`, and
  `_complete_upload_directory`
- **`route.py`**: added `admin` to `get_entity_derivations_endpoint`,
  `multipart_upload_initiate_endpoint`, `multipart_upload_complete_endpoint`,
  `multipart_upload_initiate_endpoint_directory`, and
  `multipart_upload_complete_endpoint_directory`, replacing the previous
  hardcoded `admin=False`

### Tests

- Extended `test_route.py` to cover `admin=True` for
  `get_entity_derivations_endpoint`
- Added `admin` argument to affected calls in `test_multipart_upload.py`
- Added `admin=True` client-level tests for `get_entity_derivations`,
  `upload_content`, `upload_directory`, and `list_directory`
