### PR TITLE
Use MultipartUploadTransferConfig by default when uploading a file.

### DIFF
--- a/src/entitysdk/client.py
+++ b/src/entitysdk/client.py
@@ -392,7 +392,8 @@ class Client:
             file_metadata: Optional extra metadata to attach to the asset.
             asset_label: Label for the asset.
             project_context: Optional project context.
-            transfer_config: Optional multipart upload configuration.
+            transfer_config: Optional multipart upload configuration. If not specified,
+                uses the defaults specified in ``MultipartUploadTransferConfig``.
             admin: Whether to use admin endpoints.
 
         Returns:
@@ -493,7 +494,8 @@ class Client:
             metadata: Optional extra metadata to attach to the directory asset.
             label: Label for the asset.
             project_context: Optional project context.
-            transfer_config: Optional multipart upload configuration.
+            transfer_config: Optional multipart upload configuration. If not specified,
+                uses the defaults from ``MultipartDirectoryUploadTransferConfig``.
             admin: Whether to use the admin endpoints.
 
         Returns:

--- a/src/entitysdk/core.py
+++ b/src/entitysdk/core.py
@@ -346,7 +346,9 @@ def upload_asset_file(
     admin: bool,
 ) -> Asset:
     """Upload asset to an existing entity's endpoint from a file path."""
-    if transfer_config and get_filesize(asset_path) > transfer_config.threshold:
+    transfer_config = transfer_config or MultipartUploadTransferConfig()
+
+    if get_filesize(asset_path) > transfer_config.threshold:
         L.info("File is being uploaded using multipart upload")
         return multipart_upload_asset_file(
             api_url=api_url,


### PR DESCRIPTION
Use MultipartUploadTransferConfig by default when uploading a file.

Note: this will affect any client (notebook, script, service) that initializes a client without specifying transfer_config.

In practice, there will be a difference only when uploading files bigger than 20 MB (default in `MultipartUploadTransferConfig.threshold`)