### PR TITLE
Stage ME-model e-type in SONATA nodes

### DIFF
--- a/src/entitysdk/staging/ion_channel_model.py
+++ b/src/entitysdk/staging/ion_channel_model.py
@@ -262,8 +262,6 @@ def stage_sonata_from_config(
     ion_channel_model_data: dict,
     output_dir: Path,
     radius: float = 10.0,
-    mtype: str = "",
-    etype: str = "",
     threshold_current: float = 0.0,
     holding_current: float = 0.0,
 ):
@@ -275,8 +273,6 @@ def stage_sonata_from_config(
             and conductance (or max permeability) values.
         output_dir (str or Path): Path to the output 'sonata' folder.
         radius (float): Radius of the soma in microns.
-        mtype (str): Cell mtype.
-        etype (str): Cell etype.
         threshold_current (float): Threshold current.
         holding_current (float): Holding current.
     """
@@ -305,8 +301,6 @@ def stage_sonata_from_config(
         hoc_file=str(hoc_dst),
         morph_file=str(morph_dst),
         output_file=Path(str(subdirs["network"])) / "nodes.h5",
-        mtype=mtype,
-        etype=etype,
         threshold_current=threshold_current,
         holding_current=holding_current,
         template_name="cell",

--- a/src/entitysdk/staging/ion_channel_model.py
+++ b/src/entitysdk/staging/ion_channel_model.py
@@ -263,6 +263,7 @@ def stage_sonata_from_config(
     output_dir: Path,
     radius: float = 10.0,
     mtype: str = "",
+    etype: str = "",
     threshold_current: float = 0.0,
     holding_current: float = 0.0,
 ):
@@ -275,6 +276,7 @@ def stage_sonata_from_config(
         output_dir (str or Path): Path to the output 'sonata' folder.
         radius (float): Radius of the soma in microns.
         mtype (str): Cell mtype.
+        etype (str): Cell etype.
         threshold_current (float): Threshold current.
         holding_current (float): Holding current.
     """
@@ -304,6 +306,7 @@ def stage_sonata_from_config(
         morph_file=str(morph_dst),
         output_file=Path(str(subdirs["network"])) / "nodes.h5",
         mtype=mtype,
+        etype=etype,
         threshold_current=threshold_current,
         holding_current=holding_current,
         template_name="cell",

--- a/src/entitysdk/staging/memodel.py
+++ b/src/entitysdk/staging/memodel.py
@@ -71,8 +71,8 @@ def stage_sonata_from_memodel(
     with tempfile.TemporaryDirectory() as tmp_dir:
         downloaded_me_model = download_memodel(client, memodel=memodel, output_dir=tmp_dir)
 
-        mtype = memodel.mtypes[0].pref_label if memodel.mtypes else ""
-        etype = memodel.emodel.etypes[0].pref_label if memodel.emodel.etypes else ""
+        mtype = memodel.mtypes[0].pref_label if memodel.mtypes else None
+        etype = memodel.emodel.etypes[0].pref_label if memodel.emodel.etypes else None
 
         if memodel.calibration_result is None:
             raise StagingError(f"MEModel {memodel.id} has no calibration result.")
@@ -99,8 +99,8 @@ def stage_sonata_from_memodel(
 def _generate_sonata_files_from_memodel(
     downloaded_memodel: DownloadedMEModel,
     output_path: Path,
-    mtype: str,
-    etype: str,
+    mtype: str | None,
+    etype: str | None,
     threshold_current: float,
     holding_current: float,
 ):
@@ -109,8 +109,8 @@ def _generate_sonata_files_from_memodel(
     Args:
         downloaded_memodel (DownloadedMEModel): The downloaded MEModel object.
         output_path (str or Path): Path to the output 'sonata' folder.
-        mtype (str): Cell mtype.
-        etype (str): Cell etype.
+        mtype (str | None): Cell mtype, if available.
+        etype (str | None): Cell etype, if available.
         threshold_current (float): Threshold current.
         holding_current (float): Holding current.
     """
@@ -167,11 +167,12 @@ def create_nodes_file(
     hoc_file: str,
     morph_file: str,
     output_file: Path,
-    mtype: str,
-    etype: str,
     threshold_current: float,
     holding_current: float,
     template_name: str,
+    *,
+    mtype: str | None = None,
+    etype: str | None = None,
 ):
     """Create a SONATA nodes.h5 file for a single cell population.
 
@@ -179,11 +180,11 @@ def create_nodes_file(
         hoc_file (str): Path to the hoc file.
         morph_file (str): Path to the morphology file.
         output_file (Path): Output file path for nodes.h5.
-        mtype (str): Cell mtype.
-        etype (str): Cell etype.
         threshold_current (float): Threshold current value.
         holding_current (float): Holding current value.
         template_name (str): HOC template name (from begintemplate statement).
+        mtype (str | None): Cell mtype, if available.
+        etype (str | None): Cell etype, if available.
     """
     output_file = Path(output_file)  # ensure Path type
     output_file.parent.mkdir(parents=True, exist_ok=True)
@@ -207,8 +208,10 @@ def create_nodes_file(
         group_0.create_dataset("morphology", (1,), dtype=h5py.string_dtype())[0] = (
             f"morphologies/{Path(morph_file).stem}"
         )
-        group_0.create_dataset("mtype", (1,), dtype=h5py.string_dtype())[0] = mtype
-        group_0.create_dataset("etype", (1,), dtype=h5py.string_dtype())[0] = etype
+        if mtype is not None:
+            group_0.create_dataset("mtype", (1,), dtype=h5py.string_dtype())[0] = mtype
+        if etype is not None:
+            group_0.create_dataset("etype", (1,), dtype=h5py.string_dtype())[0] = etype
 
         # Coordinates and rotation
         for name in [

--- a/src/entitysdk/staging/memodel.py
+++ b/src/entitysdk/staging/memodel.py
@@ -68,15 +68,11 @@ def stage_sonata_from_memodel(
     Returns:
         Path to generated circuit_config.json (inside SONATA folder).
     """
-    etypes = memodel.emodel.etypes or []
-    if not etypes or not etypes[0].pref_label.strip():
-        raise StagingError(f"MEModel {memodel.id} has no e-type on its associated E-model.")
-    etype = etypes[0].pref_label.strip()
-
     with tempfile.TemporaryDirectory() as tmp_dir:
         downloaded_me_model = download_memodel(client, memodel=memodel, output_dir=tmp_dir)
 
         mtype = memodel.mtypes[0].pref_label if memodel.mtypes else ""
+        etype = memodel.emodel.etypes[0].pref_label if memodel.emodel.etypes else ""
 
         if memodel.calibration_result is None:
             raise StagingError(f"MEModel {memodel.id} has no calibration result.")

--- a/src/entitysdk/staging/memodel.py
+++ b/src/entitysdk/staging/memodel.py
@@ -68,11 +68,15 @@ def stage_sonata_from_memodel(
     Returns:
         Path to generated circuit_config.json (inside SONATA folder).
     """
+    etypes = memodel.emodel.etypes or []
+    if not etypes or not etypes[0].pref_label.strip():
+        raise StagingError(f"MEModel {memodel.id} has no e-type on its associated E-model.")
+    etype = etypes[0].pref_label.strip()
+
     with tempfile.TemporaryDirectory() as tmp_dir:
         downloaded_me_model = download_memodel(client, memodel=memodel, output_dir=tmp_dir)
 
         mtype = memodel.mtypes[0].pref_label if memodel.mtypes else ""
-        etype = memodel.emodel.etypes[0].pref_label if memodel.emodel.etypes else ""
 
         if memodel.calibration_result is None:
             raise StagingError(f"MEModel {memodel.id} has no calibration result.")

--- a/src/entitysdk/staging/memodel.py
+++ b/src/entitysdk/staging/memodel.py
@@ -72,6 +72,7 @@ def stage_sonata_from_memodel(
         downloaded_me_model = download_memodel(client, memodel=memodel, output_dir=tmp_dir)
 
         mtype = memodel.mtypes[0].pref_label if memodel.mtypes else ""
+        etype = memodel.emodel.etypes[0].pref_label if memodel.emodel.etypes else ""
 
         if memodel.calibration_result is None:
             raise StagingError(f"MEModel {memodel.id} has no calibration result.")
@@ -83,6 +84,7 @@ def stage_sonata_from_memodel(
             downloaded_memodel=downloaded_me_model,
             output_path=output_dir,
             mtype=mtype,
+            etype=etype,
             threshold_current=threshold_current,
             holding_current=holding_current,
         )
@@ -98,6 +100,7 @@ def _generate_sonata_files_from_memodel(
     downloaded_memodel: DownloadedMEModel,
     output_path: Path,
     mtype: str,
+    etype: str,
     threshold_current: float,
     holding_current: float,
 ):
@@ -107,6 +110,7 @@ def _generate_sonata_files_from_memodel(
         downloaded_memodel (DownloadedMEModel): The downloaded MEModel object.
         output_path (str or Path): Path to the output 'sonata' folder.
         mtype (str): Cell mtype.
+        etype (str): Cell etype.
         threshold_current (float): Threshold current.
         holding_current (float): Holding current.
     """
@@ -147,6 +151,7 @@ def _generate_sonata_files_from_memodel(
         morph_file=str(morph_dst),
         output_file=Path(str(subdirs["network"])) / "nodes.h5",
         mtype=mtype,
+        etype=etype,
         threshold_current=threshold_current,
         holding_current=holding_current,
         template_name=template_name,
@@ -163,6 +168,7 @@ def create_nodes_file(
     morph_file: str,
     output_file: Path,
     mtype: str,
+    etype: str,
     threshold_current: float,
     holding_current: float,
     template_name: str,
@@ -174,6 +180,7 @@ def create_nodes_file(
         morph_file (str): Path to the morphology file.
         output_file (Path): Output file path for nodes.h5.
         mtype (str): Cell mtype.
+        etype (str): Cell etype.
         threshold_current (float): Threshold current value.
         holding_current (float): Holding current value.
         template_name (str): HOC template name (from begintemplate statement).
@@ -201,6 +208,7 @@ def create_nodes_file(
             f"morphologies/{Path(morph_file).stem}"
         )
         group_0.create_dataset("mtype", (1,), dtype=h5py.string_dtype())[0] = mtype
+        group_0.create_dataset("etype", (1,), dtype=h5py.string_dtype())[0] = etype
 
         # Coordinates and rotation
         for name in [

--- a/tests/unit/staging/test_ion_channel_model.py
+++ b/tests/unit/staging/test_ion_channel_model.py
@@ -1,5 +1,7 @@
 import uuid
 
+import h5py
+
 import entitysdk.staging.ion_channel_model as icm
 from entitysdk import models, types
 from entitysdk.models.ion_channel_model import IonChannelModel, NeuronBlock
@@ -204,6 +206,8 @@ def test_stage_sonata_from_config(client, tmp_path, httpx_mock, api_url, request
         client=client,
         ion_channel_model_data=ion_channel_model_data,
         output_dir=tmp_path,
+        mtype="TestMType",
+        etype="TestEType",
     )
 
     assert config_path == tmp_path / "circuit_config.json"
@@ -213,3 +217,7 @@ def test_stage_sonata_from_config(client, tmp_path, httpx_mock, api_url, request
     assert (tmp_path / "network" / "nodes.h5").exists()
     assert (tmp_path / "circuit_config.json").exists()
     assert (tmp_path / "node_sets.json").exists()
+    with h5py.File(tmp_path / "network" / "nodes.h5") as h5:
+        group = h5["nodes/All/0"]
+        assert group["mtype"].asstr()[0] == "TestMType"
+        assert group["etype"].asstr()[0] == "TestEType"

--- a/tests/unit/staging/test_ion_channel_model.py
+++ b/tests/unit/staging/test_ion_channel_model.py
@@ -206,8 +206,6 @@ def test_stage_sonata_from_config(client, tmp_path, httpx_mock, api_url, request
         client=client,
         ion_channel_model_data=ion_channel_model_data,
         output_dir=tmp_path,
-        mtype="TestMType",
-        etype="TestEType",
     )
 
     assert config_path == tmp_path / "circuit_config.json"
@@ -219,5 +217,5 @@ def test_stage_sonata_from_config(client, tmp_path, httpx_mock, api_url, request
     assert (tmp_path / "node_sets.json").exists()
     with h5py.File(tmp_path / "network" / "nodes.h5") as h5:
         group = h5["nodes/All/0"]
-        assert group["mtype"].asstr()[0] == "TestMType"
-        assert group["etype"].asstr()[0] == "TestEType"
+        assert "mtype" not in group
+        assert "etype" not in group

--- a/tests/unit/staging/test_memodel.py
+++ b/tests/unit/staging/test_memodel.py
@@ -18,7 +18,8 @@ class FakeEType:
 
 
 class FakeEModel:
-    etypes = [FakeEType()]
+    def __init__(self):
+        self.etypes = [FakeEType()]
 
 
 class FakeCalibration:
@@ -64,6 +65,27 @@ def test_stage_sonata_from_memodel_success(tmp_path, fake_memodel, fake_client):
         mock_dl.assert_called_once()
         mock_gen.assert_called_once()
         assert mock_gen.call_args.kwargs["etype"] == "cADpyr"
+
+
+def test_stage_sonata_from_memodel_preserves_missing_classifications(
+    tmp_path, fake_memodel, fake_client
+):
+    config_path = tmp_path / "circuit_config.json"
+    config_path.write_text("{}")
+    fake_memodel.mtypes = None
+    fake_memodel.emodel.etypes = None
+
+    with (
+        mock.patch.object(memodel_mod, "download_memodel"),
+        mock.patch.object(memodel_mod, "_generate_sonata_files_from_memodel") as mock_gen,
+    ):
+        result = memodel_mod.stage_sonata_from_memodel(
+            fake_client, fake_memodel, output_dir=tmp_path
+        )
+
+    assert result == config_path
+    assert mock_gen.call_args.kwargs["mtype"] is None
+    assert mock_gen.call_args.kwargs["etype"] is None
 
 
 def test_stage_sonata_from_memodel_no_calibration(tmp_path, fake_memodel_no_calib, fake_client):
@@ -121,6 +143,30 @@ def test_generate_sonata_files_from_memodel_creates_structure(tmp_path):
         assert group["etype"][0].decode() == "cADpyr"
         assert group["dynamics_params"]["holding_current"][0] == pytest.approx(-0.1)
         assert group["dynamics_params"]["threshold_current"][0] == pytest.approx(0.2)
+
+
+def test_create_nodes_file_omits_missing_classifications(tmp_path):
+    hoc_file = tmp_path / "cell.hoc"
+    morph_file = tmp_path / "cell.asc"
+    hoc_file.write_text("begintemplate MyCell\nendtemplate MyCell\n")
+    morph_file.write_text("morph content")
+    output_file = tmp_path / "network" / "nodes.h5"
+
+    memodel_mod.create_nodes_file(
+        hoc_file=str(hoc_file),
+        morph_file=str(morph_file),
+        output_file=output_file,
+        mtype=None,
+        etype=None,
+        threshold_current=0.2,
+        holding_current=-0.1,
+        template_name="MyCell",
+    )
+
+    with h5py.File(output_file) as h5:
+        group = h5["nodes/All/0"]
+        assert "mtype" not in group
+        assert "etype" not in group
 
 
 def test_create_json_configs(tmp_path):

--- a/tests/unit/staging/test_memodel.py
+++ b/tests/unit/staging/test_memodel.py
@@ -14,13 +14,11 @@ class FakeMType:
 
 
 class FakeEType:
-    def __init__(self, pref_label="cADpyr"):
-        self.pref_label = pref_label
+    pref_label = "cADpyr"
 
 
 class FakeEModel:
-    def __init__(self):
-        self.etypes = [FakeEType()]
+    etypes = [FakeEType()]
 
 
 class FakeCalibration:
@@ -74,17 +72,6 @@ def test_stage_sonata_from_memodel_no_calibration(tmp_path, fake_memodel_no_cali
             memodel_mod.stage_sonata_from_memodel(
                 fake_client, fake_memodel_no_calib, output_dir=tmp_path
             )
-
-
-@pytest.mark.parametrize("etypes", [None, [], [FakeEType("")], [FakeEType("   ")]])
-def test_stage_sonata_from_memodel_requires_etype(tmp_path, fake_memodel, fake_client, etypes):
-    fake_memodel.emodel.etypes = etypes
-
-    with mock.patch.object(memodel_mod, "download_memodel") as mock_dl:
-        with pytest.raises(StagingError, match="has no e-type"):
-            memodel_mod.stage_sonata_from_memodel(fake_client, fake_memodel, output_dir=tmp_path)
-
-    mock_dl.assert_not_called()
 
 
 def test_generate_sonata_files_from_memodel_creates_structure(tmp_path):

--- a/tests/unit/staging/test_memodel.py
+++ b/tests/unit/staging/test_memodel.py
@@ -13,6 +13,14 @@ class FakeMType:
     pref_label = "L5_TTPC1"
 
 
+class FakeEType:
+    pref_label = "cADpyr"
+
+
+class FakeEModel:
+    etypes = [FakeEType()]
+
+
 class FakeCalibration:
     threshold_current = 0.234
     holding_current = -0.123
@@ -22,6 +30,7 @@ class FakeMEModel:
     def __init__(self, with_calibration=True):
         self.id = "fake_id"
         self.mtypes = [FakeMType()]
+        self.emodel = FakeEModel()
         self.calibration_result = FakeCalibration() if with_calibration else None
 
 
@@ -54,6 +63,7 @@ def test_stage_sonata_from_memodel_success(tmp_path, fake_memodel, fake_client):
         assert result == config_path
         mock_dl.assert_called_once()
         mock_gen.assert_called_once()
+        assert mock_gen.call_args.kwargs["etype"] == "cADpyr"
 
 
 def test_stage_sonata_from_memodel_no_calibration(tmp_path, fake_memodel_no_calib, fake_client):
@@ -91,6 +101,7 @@ def test_generate_sonata_files_from_memodel_creates_structure(tmp_path):
         downloaded_memodel=downloaded_me_model,
         output_path=output_path,
         mtype="L5_TTPC1",
+        etype="cADpyr",
         threshold_current=0.2,
         holding_current=-0.1,
     )
@@ -107,6 +118,7 @@ def test_generate_sonata_files_from_memodel_creates_structure(tmp_path):
         group = f["nodes"]["All"]["0"]
         assert group["model_template"][0].decode() == "hoc:TestCell"
         assert group["mtype"][0].decode() == "L5_TTPC1"
+        assert group["etype"][0].decode() == "cADpyr"
         assert group["dynamics_params"]["holding_current"][0] == pytest.approx(-0.1)
         assert group["dynamics_params"]["threshold_current"][0] == pytest.approx(0.2)
 
@@ -123,6 +135,7 @@ def test_create_json_configs(tmp_path):
         morph_file=str(morph_file),
         output_file=network_dir / "nodes.h5",
         mtype="L5_TTPC1",
+        etype="cADpyr",
         threshold_current=0.2,
         holding_current=-0.1,
         template_name="MyCell",
@@ -163,6 +176,7 @@ def test_missing_hoc_file_raise(tmp_path):
             downloaded_memodel=downloaded_me_model,
             output_path=tmp_path,
             mtype="Test",
+            etype="TestEType",
             threshold_current=0.2,
             holding_current=-0.1,
         )
@@ -187,6 +201,7 @@ def test_missing_morphology_file_raises(tmp_path):
             downloaded_memodel=downloaded_me_model,
             output_path=tmp_path,
             mtype="Test",
+            etype="TestEType",
             threshold_current=0.2,
             holding_current=-0.1,
         )
@@ -212,6 +227,7 @@ def test_mechanism_file_not_exists(tmp_path):
         downloaded_memodel=downloaded_me_model,
         output_path=tmp_path,
         mtype="Test",
+        etype="TestEType",
         threshold_current=0.2,
         holding_current=-0.1,
     )

--- a/tests/unit/staging/test_memodel.py
+++ b/tests/unit/staging/test_memodel.py
@@ -14,11 +14,13 @@ class FakeMType:
 
 
 class FakeEType:
-    pref_label = "cADpyr"
+    def __init__(self, pref_label="cADpyr"):
+        self.pref_label = pref_label
 
 
 class FakeEModel:
-    etypes = [FakeEType()]
+    def __init__(self):
+        self.etypes = [FakeEType()]
 
 
 class FakeCalibration:
@@ -72,6 +74,17 @@ def test_stage_sonata_from_memodel_no_calibration(tmp_path, fake_memodel_no_cali
             memodel_mod.stage_sonata_from_memodel(
                 fake_client, fake_memodel_no_calib, output_dir=tmp_path
             )
+
+
+@pytest.mark.parametrize("etypes", [None, [], [FakeEType("")], [FakeEType("   ")]])
+def test_stage_sonata_from_memodel_requires_etype(tmp_path, fake_memodel, fake_client, etypes):
+    fake_memodel.emodel.etypes = etypes
+
+    with mock.patch.object(memodel_mod, "download_memodel") as mock_dl:
+        with pytest.raises(StagingError, match="has no e-type"):
+            memodel_mod.stage_sonata_from_memodel(fake_client, fake_memodel, output_dir=tmp_path)
+
+    mock_dl.assert_not_called()
 
 
 def test_generate_sonata_files_from_memodel_creates_structure(tmp_path):


### PR DESCRIPTION
Adds the missing etype to staged single-cell SONATA nodes, sourced from the ME-model’s E-model classification. This satisfies the BluePySnap biophysical-node requirement. Missing mtype and etype classifications are omitted instead of being written as empty strings.