### PR TITLE
Add circuit_simplification types and NEST target simulator

### DIFF
--- a/src/entitysdk/_server_schemas.py
+++ b/src/entitysdk/_server_schemas.py
@@ -335,6 +335,7 @@ class DerivationType(StrEnum):
     em_dense_reconstruction_dataset_cell_morphology = (
         "em_dense_reconstruction_dataset_cell_morphology"
     )
+    circuit_simplification = "circuit_simplification"
     unspecified = "unspecified"
 
 
@@ -2141,6 +2142,7 @@ class TargetSimulator(StrEnum):
     Brian2 = "Brian2"
     CORENEURON = "CORENEURON"
     LearningEngine = "LearningEngine"
+    NEST = "NEST"
     NEURON = "NEURON"
 
 
@@ -2185,6 +2187,8 @@ class TaskActivityType(StrEnum):
     circuit_synaptic_physiology_assignment__execution = (
         "circuit_synaptic_physiology_assignment__execution"
     )
+    circuit_simplification__config_generation = "circuit_simplification__config_generation"
+    circuit_simplification__execution = "circuit_simplification__execution"
 
 
 class TaskActivityUserUpdate(BaseModel):
@@ -2236,6 +2240,8 @@ class TaskConfigType(StrEnum):
     circuit_synaptic_physiology_assignment__config = (
         "circuit_synaptic_physiology_assignment__config"
     )
+    circuit_simplification__campaign = "circuit_simplification__campaign"
+    circuit_simplification__config = "circuit_simplification__config"
 
 
 class TaskConfigUserUpdate(BaseModel):


### PR DESCRIPTION
Add the following enum values needed by the obi-one circuit simplification task (PR #897):

TargetSimulator:
  - NEST = 'NEST'

DerivationType:
  - circuit_simplification

TaskActivityType:
  - circuit_simplification__config_generation
  - circuit_simplification__execution

TaskConfigType:
  - circuit_simplification__campaign
  - circuit_simplification__config