### PR TITLE
Add circuit single build task types

### DIFF
--- a/src/entitysdk/_server_schemas.py
+++ b/src/entitysdk/_server_schemas.py
@@ -2301,6 +2301,8 @@ class TaskActivityType(StrEnum):
     )
     circuit_simplification__config_generation = "circuit_simplification__config_generation"
     circuit_simplification__execution = "circuit_simplification__execution"
+    circuit_single_build__config_generation = "circuit_single_build__config_generation"
+    circuit_single_build__execution = "circuit_single_build__execution"
 
 
 class TaskActivityUserUpdate(BaseModel):
@@ -2354,6 +2356,8 @@ class TaskConfigType(StrEnum):
     )
     circuit_simplification__campaign = "circuit_simplification__campaign"
     circuit_simplification__config = "circuit_simplification__config"
+    circuit_single_build__campaign = "circuit_single_build__campaign"
+    circuit_single_build__config = "circuit_single_build__config"
 
 
 class TaskConfigUserUpdate(BaseModel):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -8,7 +8,13 @@ from entitysdk.models.types import (
     ensure_id_is_none,
     ensure_id_is_set,
 )
-from entitysdk.types import AssetLabel, ContentType, StorageType
+from entitysdk.types import (
+    AssetLabel,
+    ContentType,
+    StorageType,
+    TaskActivityType,
+    TaskConfigType,
+)
 from tests.unit.util import MOCK_UUID
 
 
@@ -65,3 +71,14 @@ def test_ensure_id_is_set_rejects_asset_without_id():
 
 def test_asset_label_includes_compartment_sets():
     assert AssetLabel.compartment_sets.value == "compartment_sets"
+
+
+def test_task_types_include_circuit_single_build():
+    assert TaskConfigType.circuit_single_build__campaign.value == ("circuit_single_build__campaign")
+    assert TaskConfigType.circuit_single_build__config.value == "circuit_single_build__config"
+    assert TaskActivityType.circuit_single_build__config_generation.value == (
+        "circuit_single_build__config_generation"
+    )
+    assert TaskActivityType.circuit_single_build__execution.value == (
+        "circuit_single_build__execution"
+    )


### PR DESCRIPTION
Needed for: https://github.com/openbraininstitute/prod-singlecell-simulation/issues/297

Regenerates the EntitySDK server schemas with the new `circuit_single_build` task config and activity types introduced in EntityCore.

Adds:
- circuit_single_build__campaign
- circuit_single_build__config
- circuit_single_build__config_generation
- circuit_single_build__execution

Depends on: https://github.com/openbraininstitute/entitycore/pull/698